### PR TITLE
feat: add authenticate header helpers (`basic`, `bearer`, `userAgent`)

### DIFF
--- a/Sources/Networking/HTTPRequest.swift
+++ b/Sources/Networking/HTTPRequest.swift
@@ -81,6 +81,7 @@ extension HTTPRequest {
     /// - Returns: Self for method chaining.
     @discardableResult
     func userAgent(_ value: String) -> HTTPRequest {
+        guard !value.isEmpty else { return self }
         self.headers["User-Agent"] = value
         return self
     }

--- a/Sources/Networking/HTTPRequest.swift
+++ b/Sources/Networking/HTTPRequest.swift
@@ -60,9 +60,7 @@ extension HTTPRequest {
     /// - Returns: Self for method chaining.
     @discardableResult
     func basic(username: String, password: String) -> HTTPRequest {
-        let credential = "\(username):\(password)"
-        guard let data = credential.data(using: .utf8) else { return self }
-        let base64 = data.base64EncodedString()
+        let base64 = Data("\(username):\(password)".utf8).base64EncodedString()
         self.headers["Authorization"] = "Basic \(base64)"
         return self
     }

--- a/Sources/Networking/HTTPRequest.swift
+++ b/Sources/Networking/HTTPRequest.swift
@@ -51,6 +51,41 @@ extension HTTPRequest {
         self.headers.merge(headers) { _, new in new }
         return self
     }
+
+    /// Sets HTTP Basic Authentication header using the provided username and password.
+    ///
+    /// - Parameters:
+    ///   - username: The username for basic auth.
+    ///   - password: The password for basic auth.
+    /// - Returns: Self for method chaining.
+    @discardableResult
+    func basic(username: String, password: String) -> HTTPRequest {
+        let credential = "\(username):\(password)"
+        guard let data = credential.data(using: .utf8) else { return self }
+        let base64 = data.base64EncodedString()
+        self.headers["Authorization"] = "Basic \(base64)"
+        return self
+    }
+
+    /// Sets HTTP Bearer Authorization header using the provided token.
+    ///
+    /// - Parameter token: The bearer token.
+    /// - Returns: Self for method chaining.
+    @discardableResult
+    func bearer(token: String) -> HTTPRequest {
+        self.headers["Authorization"] = "Bearer \(token)"
+        return self
+    }
+
+    /// Sets the User-Agent header to identify the client.
+    ///
+    /// - Parameter value: The User-Agent string.
+    /// - Returns: Self for method chaining.
+    @discardableResult
+    func userAgent(_ value: String) -> HTTPRequest {
+        self.headers["User-Agent"] = value
+        return self
+    }
 }
 
 // MARK: - Query Parameters

--- a/Tests/NetworkingTests/UnitTests/HTTPRequestTests.swift
+++ b/Tests/NetworkingTests/UnitTests/HTTPRequestTests.swift
@@ -49,6 +49,60 @@ struct HTTPRequestBuilderTests {
         #expect(request.headers == expectedHeaders)
     }
 
+    /// Test if basic authentication header is set correctly
+    ///
+    /// **Acceptance Criteria:** \
+    /// Given an HTTPRequest instance \
+    /// When setting basic credentials \
+    /// Then the `Authorization` header should be set to `Basic <base64>` correctly
+    @Test("Basic auth header should be set correctly")
+    func setBasicAuthorizationHeader() {
+        let username = "user"
+        let password = "pass"
+        let credential = "\(username):\(password)"
+        let encoded = Data(credential.utf8).base64EncodedString()
+        let expectedHeader = ["Authorization": "Basic \(encoded)"]
+
+        let request = HTTPRequest(url: .dummyURL, method: .GET)
+            .basic(username: username, password: password)
+
+        #expect(request.headers == expectedHeader)
+    }
+
+    /// Test if the bearer authentication header is set correctly
+    ///
+    /// **Acceptance Criteria:** \
+    /// Given an HTTPRequest instance \
+    /// When setting a bearer token \
+    /// Then the `Authorization` header should be set to `Bearer <token>` correctly
+    @Test("Bearer auth header should be set correctly")
+    func setBearerAuthorizationHeader() {
+        let token = "mytoken"
+        let expectedHeader = ["Authorization": "Bearer \(token)"]
+
+        let request = HTTPRequest(url: .dummyURL, method: .GET)
+            .bearer(token: token)
+
+        #expect(request.headers == expectedHeader)
+    }
+
+    /// Test if the User-Agent header is set correctly
+    ///
+    /// **Acceptance Criteria:** \
+    /// Given an HTTPRequest instance \
+    /// When setting a User-Agent value \
+    /// Then the `User-Agent` header should be set correctly
+    @Test("User-Agent header should be set correctly")
+    func setUserAgentHeader() {
+        let ua = "MyAgent/1.0"
+        let expectedHeader = ["User-Agent": ua]
+
+        let request = HTTPRequest(url: .dummyURL, method: .GET)
+            .userAgent(ua)
+
+        #expect(request.headers == expectedHeader)
+    }
+
     /// Test if a single query parameter is added correctly
     ///
     /// **Acceptance Criteria:** \
@@ -127,7 +181,7 @@ struct HTTPRequestBuilderTests {
     /// And the data will failed when encoding to JSON \
     /// Then an encoding error should be thrown
     @Test("Encoding error should be thrown for invalid JSON body")
-    func setJSONBodyWithEncodingError() {
+    func setJSONBodyWithInvalidObject() {
         struct InvalidObject: Encodable {
             func encode(to _: Encoder) throws {
                 throw EncodingError.invalidValue(
@@ -145,6 +199,22 @@ struct HTTPRequestBuilderTests {
         #expect(throws: EncodingError.self) {
             try HTTPRequest(url: .dummyURL, method: .POST).jsonBody(invalidObject)
         }
+    }
+
+    /// Test if acceptable status code range is configured correctly
+    ///
+    /// **Acceptance Criteria:** \
+    /// Given an HTTPRequest instance and status code range \
+    /// When setting acceptable status codes \
+    /// Then the status code range should be configured in the request
+    @Test("Acceptable status code range should be configured correctly")
+    func setAcceptableStatusCodes() {
+        let expectedRange = 200...200
+
+        let request = HTTPRequest(url: .dummyURL, method: .GET)
+            .acceptStatusCodes(expectedRange)
+
+        #expect(request.validStatusCodes == expectedRange)
     }
 
     /// Test if timeout interval is configured correctly


### PR DESCRIPTION
## Description

This PR adds convenience support for commonly used HTTP authorization and user-agent headers on `HTTPRequest`.

Changes:
- Modified `Sources/Networking/HTTPRequest.swift` to add helpers for:
  - `basic` Authorization header (Basic auth with base64-encoded credentials)
  - `bearer` Authorization header (Bearer token)
  - `userAgent` header for setting User-Agent
- Updated tests in `Tests/NetworkingTests/UnitTests/HTTPRequestTests.swift` to cover the new header helpers.

This change is limited in scope to header convenience APIs and corresponding unit tests. No public API breaking changes are expected.

---

## How Has This Been Tested?

<img width="1318" height="901" alt="Screenshot 2025-09-15 at 10 31 17 AM" src="https://github.com/user-attachments/assets/199ce83f-5067-4da7-ab10-aceee07c8025" />

---

## Screenshots / Examples (if applicable)

N/A - No UI changes

---

## Additional Notes

N/A
