### PR TITLE
chore: add CI, automation, and release workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,67 @@
+name: Documentation
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-docs:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build documentation
+        run: |
+          swift package \
+            --allow-writing-to-directory ./docs \
+            generate-documentation \
+            --target Networking \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path swift-networking \
+            --output-path ./docs
+
+      - name: Deploy to GitHub Pages
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Fetch gh-pages or create it as an orphan branch
+          if git ls-remote --exit-code origin gh-pages > /dev/null 2>&1; then
+            git fetch origin gh-pages
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf . 2>/dev/null || true
+          fi
+
+          # Copy docs to versioned directory
+          rm -rf "$VERSION"
+          cp -r docs "$VERSION"
+
+          # Copy docs to root as latest
+          find . -maxdepth 1 \
+            -not -name '.' \
+            -not -name '.git' \
+            -not -name '.nojekyll' \
+            -not -regex './[0-9].*' \
+            -exec rm -rf {} +
+          cp -r docs/* .
+
+          # Ensure GitHub Pages doesn't process with Jekyll
+          touch .nojekyll
+
+          # Commit and push
+          git add -A
+          git commit -m "docs: deploy $VERSION documentation" || echo "No changes to commit"
+          git push origin gh-pages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          brew install swiftlint
+          brew install swift-format
+
+      - name: Check formatting
+        run: make format-check
+
+      - name: Lint
+        run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'Sources/**'
+      - 'Tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,72 @@
+name: Move issue to In Progress on branch creation
+
+on:
+  create:
+
+jobs:
+  move-to-in-progress:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue number from branch name
+        id: extract
+        run: |
+          BRANCH="${{ github.event.ref }}"
+          # Match pattern: type/123-description
+          if [[ "$BRANCH" =~ ^[a-z]+/([0-9]+)- ]]; then
+            echo "issue_number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No issue number found in branch: $BRANCH"
+            exit 0
+          fi
+
+      - name: Move issue to In Progress
+        if: steps.extract.outputs.issue_number
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          ISSUE_NUMBER="${{ steps.extract.outputs.issue_number }}"
+          PROJECT_ID="PVT_kwHOBZJyrs4BT0js"
+          STATUS_FIELD_ID="PVTSSF_lAHOBZJyrs4BT0jszhBA0sc"
+          IN_PROGRESS_ID="3bb3bc18"
+
+          # Find the project item for this issue
+          ITEM_ID=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $issue: Int!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issue) {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { id }
+                    }
+                  }
+                }
+              }
+            }' -f owner="${{ github.repository_owner }}" \
+               -f repo="${{ github.event.repository.name }}" \
+               -F issue="$ISSUE_NUMBER" \
+               --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue #$ISSUE_NUMBER is not in the project. Skipping."
+            exit 0
+          fi
+
+          # Update status to In Progress
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item { id }
+              }
+            }' -f projectId="$PROJECT_ID" \
+               -f itemId="$ITEM_ID" \
+               -f fieldId="$STATUS_FIELD_ID" \
+               -f optionId="$IN_PROGRESS_ID"
+
+          echo "Moved issue #$ISSUE_NUMBER to In Progress"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,18 @@ name: Test
 on:
   push:
     branches: [main]
+    paths:
+      - 'Sources/**'
+      - 'Tests/**'
+      - 'Package.swift'
+      - 'Package@*.swift'
   pull_request:
     branches: [main]
+    paths:
+      - 'Sources/**'
+      - 'Tests/**'
+      - 'Package.swift'
+      - 'Package@*.swift'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test


### PR DESCRIPTION
### Refactor / Chore
Add GitHub Actions workflows for CI, project board automation, and release pipeline.

**Workflows added:**
- `test.yml` — build + test on push to main and PRs
- `lint.yml` — format check + swiftlint on PRs
- `project-automation.yml` — moves issue to In Progress when a branch matching `type/ISSUE-description` is created
- `release.yml` — creates GitHub Release with auto-generated notes on tag push
- `docs.yml` — builds DocC and deploys versioned + latest to gh-pages on tag push

---

## Test Plan
- Workflows are validated as correct YAML
- Functional testing will happen on first real issue/branch/PR cycle

---

## Checklist

- [x] `make build` passes
- [x] `make lint` passes
- [ ] New/changed public API has documentation
- [ ] Breaking changes are noted above