### PR TITLE
chore: add labels, auto-labeling, and release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  categories:
+    - title: "New Features"
+      labels:
+        - feature
+    - title: "Bug Fixes"
+      labels:
+        - bug
+    - title: "Performance"
+      labels:
+        - perf
+    - title: "Refactoring"
+      labels:
+        - refactor
+    - title: "Documentation"
+      labels:
+        - docs
+    - title: "Testing"
+      labels:
+        - test
+    - title: "Other"
+      labels:
+        - chore
+        - "*"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -51,37 +51,32 @@ jobs:
           PR_NUMBER="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
-
           LABELS=""
-
-          add_label() {
-            if echo "$LABELS" | grep -qv "$1"; then
-              LABELS="$LABELS $1"
-            fi
-          }
 
           while IFS= read -r file; do
             case "$file" in
               Sources/Networking/Client/*|Sources/Networking/Request/*|Sources/Networking/Response/*|Sources/Networking/Transport/*)
-                add_label "area: core" ;;
+                LABELS="$LABELS"$'\n'"area: core" ;;
               Sources/Networking/Middleware/*)
-                add_label "area: middleware" ;;
+                LABELS="$LABELS"$'\n'"area: middleware" ;;
               Sources/Networking/Macros/*|Sources/NetworkingMacros/*)
-                add_label "area: macro" ;;
+                LABELS="$LABELS"$'\n'"area: macro" ;;
               Sources/NetworkingSSE/*)
-                add_label "area: sse" ;;
+                LABELS="$LABELS"$'\n'"area: sse" ;;
               Sources/NetworkingWebSocket/*)
-                add_label "area: websocket" ;;
+                LABELS="$LABELS"$'\n'"area: websocket" ;;
               Sources/Networking/Encoding/*)
-                add_label "area: encoding" ;;
+                LABELS="$LABELS"$'\n'"area: encoding" ;;
               Tests/*)
-                add_label "area: test" ;;
+                LABELS="$LABELS"$'\n'"area: test" ;;
               .github/*)
-                add_label "area: ci" ;;
+                LABELS="$LABELS"$'\n'"area: ci" ;;
             esac
           done <<< "$FILES"
 
-          for label in $LABELS; do
+          # Deduplicate and apply labels
+          echo "$LABELS" | sort -u | while IFS= read -r label; do
+            [ -z "$label" ] && continue
             gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"
             echo "Added label: $label"
           done

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,87 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-by-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by branch prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          PREFIX="${BRANCH%%/*}"
+
+          case "$PREFIX" in
+            feat)     LABEL="feature" ;;
+            fix)      LABEL="bug" ;;
+            refactor) LABEL="refactor" ;;
+            chore)    LABEL="chore" ;;
+            test)     LABEL="test" ;;
+            docs)     LABEL="docs" ;;
+            perf)     LABEL="perf" ;;
+            *)        LABEL="" ;;
+          esac
+
+          if [ -n "$LABEL" ]; then
+            gh pr edit "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" \
+              --add-label "$LABEL"
+            echo "Added label: $LABEL"
+          else
+            echo "No matching label for branch prefix: $PREFIX"
+          fi
+
+  label-by-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Label by changed files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+          FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+
+          LABELS=""
+
+          add_label() {
+            if echo "$LABELS" | grep -qv "$1"; then
+              LABELS="$LABELS $1"
+            fi
+          }
+
+          while IFS= read -r file; do
+            case "$file" in
+              Sources/Networking/Client/*|Sources/Networking/Request/*|Sources/Networking/Response/*|Sources/Networking/Transport/*)
+                add_label "area: core" ;;
+              Sources/Networking/Middleware/*)
+                add_label "area: middleware" ;;
+              Sources/Networking/Macros/*|Sources/NetworkingMacros/*)
+                add_label "area: macro" ;;
+              Sources/NetworkingSSE/*)
+                add_label "area: sse" ;;
+              Sources/NetworkingWebSocket/*)
+                add_label "area: websocket" ;;
+              Sources/Networking/Encoding/*)
+                add_label "area: encoding" ;;
+              Tests/*)
+                add_label "area: test" ;;
+              .github/*)
+                add_label "area: ci" ;;
+            esac
+          done <<< "$FILES"
+
+          for label in $LABELS; do
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"
+            echo "Added label: $label"
+          done


### PR DESCRIPTION
### Refactor / Chore
Add repository labels, auto-labeling workflow, and release notes configuration.

**Labels created:**
- Change type: `feature`, `bug`, `refactor`, `chore`, `test`, `docs`, `perf`
- Area: `area: core`, `area: macro`, `area: middleware`, `area: sse`, `area: websocket`, `area: encoding`, `area: ci`, `area: test`

**Auto-label workflow:**
- Labels PRs by branch prefix (`feat/` → `feature`, `fix/` → `bug`, etc.)
- Labels PRs by changed file paths (`Sources/Networking/Middleware/` → `area: middleware`, etc.)

**Release notes config:**
- Groups changelog entries by label (features, bug fixes, performance, etc.)

---

## Test Plan
- Labels verified via `gh label list`
- Auto-labeling will be tested on the next feature PR with source changes
- Release notes config will be tested on first tag push

---

## Checklist

- [x] `make build` passes
- [x] `make lint` passes
- [ ] New/changed public API has documentation
- [ ] Breaking changes are noted above