### PR TITLE
docs: add design specs for networking library

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,16 +3,29 @@ name: Lint
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'Sources/**'
-      - 'Tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'Sources/**'
+              - 'Tests/**'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,25 +3,33 @@ name: Test
 on:
   push:
     branches: [main]
-    paths:
-      - 'Sources/**'
-      - 'Tests/**'
-      - 'Package.swift'
-      - 'Package@*.swift'
   pull_request:
     branches: [main]
-    paths:
-      - 'Sources/**'
-      - 'Tests/**'
-      - 'Package.swift'
-      - 'Package@*.swift'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'Sources/**'
+              - 'Tests/**'
+              - 'Package.swift'
+              - 'Package@*.swift'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/networking/specs/encoding.md
+++ b/docs/networking/specs/encoding.md
@@ -1,0 +1,148 @@
+# Encoding & Content Types
+
+## Protocols
+
+```swift
+protocol ResponseDecoding: Sendable {
+    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T
+}
+
+protocol RequestEncoding: Sendable {
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+protocol ResponseMapping: Sendable {
+    func map(_ data: Data) throws -> Data
+}
+
+extension JSONDecoder: ResponseDecoding {}
+extension JSONEncoder: RequestEncoding {}
+```
+
+Users plug in custom encoders/decoders without subclassing.
+
+## ContentType
+
+```swift
+enum ContentType: Sendable {
+    case applicationJSON
+    case formURLEncoded
+    case multipartFormData(boundary: String)
+    case text
+    case xml
+    case octetStream
+    case custom(String)
+
+    var rawValue: String { ... }
+}
+```
+
+## Body Encoding by Type and Annotation
+
+| Body type | Annotation | Encoding |
+|---|---|---|
+| `Encodable` | None or `@ContentType(.applicationJSON)` | `network.defaultEncoder.encode(body)` + JSON content type |
+| `Encodable` | `@ContentType(.formURLEncoded)` | `FormURLEncoder().encode(body)` + form content type |
+| `Encodable` | `@Encoder(Custom.self)` | `Custom().encode(body)` |
+| `MultipartFormData` | None (inferred from type) | `body.encoded()` + `body.contentType` |
+| `String` | `@ContentType(.text)` | `Data(body.utf8)` + text content type |
+| `Data` | `@ContentType(.octetStream)` | Raw Data + octet-stream content type |
+
+`@ContentType(.multipartFormData)` is not needed — the macro detects `MultipartFormData` body type automatically.
+
+## Response Decoding
+
+Default: `NetworkClient.defaultDecoder` (JSONDecoder).
+
+Per-endpoint override: `@Decoder(CustomDecoder.self)` sets `metadata.decoder`.
+
+`NetworkClient.send()` uses `metadata.decoder ?? defaultDecoder`.
+
+## Response Mapping
+
+For envelope unwrapping or response transformation:
+
+- **Global:** `NetworkClient.responseMapper(EnvelopeUnwrapper.self)` or `MapResponse` middleware
+- **Per-endpoint:** `@ResponseMapper(LegacyMapper.self)` sets `metadata.responseMapper`
+
+Applied after status validation, before decoding.
+
+## QueryEncoder
+
+Encodes `Encodable` types into `[URLQueryItem]` for complex query parameters:
+
+```swift
+struct QueryEncoder: Sendable {
+    var arrayEncoding: ArrayEncoding = .repeatKey
+    var boolEncoding: BoolEncoding = .literal
+
+    enum ArrayEncoding: Sendable {
+        case repeatKey        // ids=1&ids=2
+        case bracketed        // ids[]=1&ids[]=2
+        case commaSeparated   // ids=1,2
+    }
+
+    enum BoolEncoding: Sendable {
+        case literal    // true/false
+        case numeric    // 1/0
+    }
+
+    func encode<T: Encodable>(_ value: T) throws -> [URLQueryItem]
+}
+```
+
+Flattens struct properties into key-value pairs. Optional properties with nil values are omitted.
+
+Configurable on NetworkClient:
+
+```swift
+NetworkClient(baseURL: "...")
+    .queryEncoder(QueryEncoder(arrayEncoding: .bracketed))
+```
+
+## MultipartFormData
+
+Builder pattern for multipart request bodies:
+
+```swift
+struct MultipartFormData: Sendable {
+    let boundary: String
+
+    func field(_ name: String, _ value: String) -> MultipartFormData
+    func file(_ name: String, data: Data, fileName: String, mimeType: String) -> MultipartFormData
+
+    func encoded() -> Data
+    var contentType: ContentType { .multipartFormData(boundary: boundary) }
+}
+```
+
+```swift
+let form = MultipartFormData()
+    .field("name", "John")
+    .field("bio", "Swift developer")
+    .file("avatar", data: imageData, fileName: "avatar.jpg", mimeType: "image/jpeg")
+```
+
+## FileData
+
+For typed file references:
+
+```swift
+struct FileData: Sendable {
+    var data: Data
+    var fileName: String
+    var mimeType: String
+}
+```
+
+## FormURLEncoder
+
+Encodes `Encodable` into `application/x-www-form-urlencoded` body format:
+
+```swift
+struct FormURLEncoder: RequestEncoding {
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+```
+
+Used when `@ContentType(.formURLEncoded)` is set.

--- a/docs/networking/specs/errors.md
+++ b/docs/networking/specs/errors.md
@@ -1,0 +1,122 @@
+# Error Types
+
+## Design
+
+Single struct with a `Kind` enum. Carries full context (request, response) and supports Swift pattern matching on status codes.
+
+```swift
+struct NetworkError: Error, Sendable {
+    var kind: Kind
+    var request: Request
+    var response: Response?
+
+    enum Kind: Sendable {
+        case invalidStatus(Int)
+        case decodingFailed(any Error & Sendable)
+        case transportFailed(any Error & Sendable)
+        case encodingFailed(any Error & Sendable)
+    }
+}
+```
+
+## Error Sources
+
+| Kind | When | Has response? |
+|---|---|---|
+| `.invalidStatus(code)` | Status code not in valid set (default 200-299) | Yes |
+| `.decodingFailed(error)` | Response body can't decode as expected type | Yes |
+| `.transportFailed(error)` | Network failure, timeout, DNS, etc. | No |
+| `.encodingFailed(error)` | Request body can't be encoded | No |
+
+## Pattern Matching
+
+Switch on `error.kind` with range patterns:
+
+```swift
+do {
+    let user = try await api.users.getUser("123")
+} catch {
+    switch error.kind {
+    case .invalidStatus(404):
+        showNotFound()
+    case .invalidStatus(429):
+        let retryAfter = error[header: .custom("Retry-After")]
+        showRateLimited(retryAfter)
+    case .invalidStatus(400...499):
+        let message = error.decoded(as: APIError.self)?.message
+        showError(message ?? "Client error")
+    case .invalidStatus(500...):
+        showServerError()
+    case .transportFailed:
+        showOffline()
+    case .decodingFailed:
+        log("Bad response: \(String(data: error.body ?? Data(), encoding: .utf8) ?? "")")
+        showGenericError()
+    case .encodingFailed:
+        showGenericError()
+    }
+}
+```
+
+## Convenience Properties
+
+```swift
+extension NetworkError {
+    var statusCode: Int? {
+        if case .invalidStatus(let code) = kind { code } else { nil }
+    }
+    var body: Data? { response?.body }
+    var headers: [String: String]? { response?.headers }
+
+    var isHTTPError: Bool { ... }
+    var isClientError: Bool { statusCode.map { (400...499).contains($0) } ?? false }
+    var isServerError: Bool { statusCode.map { (500...599).contains($0) } ?? false }
+    var isTransportError: Bool { ... }
+    var isDecodingError: Bool { ... }
+    var isRetryable: Bool { isServerError || isTransportError }
+
+    subscript(header key: HeaderKey) -> String? { response?[header: key] }
+
+    func decoded<T: Decodable>(as type: T.Type) -> T? {
+        guard let body else { return nil }
+        return try? JSONDecoder().decode(type, from: body)
+    }
+
+    var underlyingError: (any Error & Sendable)? {
+        switch kind {
+        case .invalidStatus: nil
+        case .decodingFailed(let e): e
+        case .transportFailed(let e): e
+        case .encodingFailed(let e): e
+        }
+    }
+}
+```
+
+## Test Factory Methods
+
+```swift
+extension NetworkError {
+    static func http(statusCode: Int, body: Data = Data()) -> NetworkError {
+        NetworkError(
+            kind: .invalidStatus(statusCode),
+            request: Request(method: .get, path: "/mock"),
+            response: Response(statusCode: statusCode, headers: [:], body: body)
+        )
+    }
+
+    static func transportError(_ error: any Error & Sendable) -> NetworkError {
+        NetworkError(
+            kind: .transportFailed(error),
+            request: Request(method: .get, path: "/mock"),
+            response: nil
+        )
+    }
+}
+```
+
+## Status Validation
+
+Default: 200-299. Override with `@ValidStatus(codes)`.
+
+For Optional return types: if status code is valid but body is empty or not decodable, return `nil` instead of throwing. This is how `@ValidStatus(200, 404)` + `User?` works.

--- a/docs/networking/specs/feature-types.md
+++ b/docs/networking/specs/feature-types.md
@@ -1,0 +1,175 @@
+# Feature Types
+
+## HTTPMethod
+
+```swift
+enum HTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}
+
+extension HTTPMethod {
+    var isIdempotent: Bool {
+        switch self {
+        case .get, .put, .delete: true
+        case .post, .patch: false
+        }
+    }
+}
+```
+
+Used by `Retry` middleware when `metadata.idempotent` is nil — falls back to method-based inference.
+
+## HeaderKey
+
+```swift
+enum HeaderKey: Sendable, Hashable {
+    case accept
+    case authorization
+    case cacheControl
+    case contentType
+    case userAgent
+    case custom(String)
+
+    var rawValue: String { ... }
+}
+```
+
+Used in:
+- Request/Response subscripts: `request[header: .authorization]`
+- `@Header` annotation: `@Header(.accept, "application/json")`
+- Default headers: `.defaultHeaders([.accept: "application/json"])`
+
+## RetryPolicy + RetryCondition
+
+```swift
+struct RetryPolicy: Sendable {
+    var strategy: Strategy
+    var conditions: [RetryCondition]
+
+    enum Strategy: Sendable {
+        case exponential(max: Int, baseDelay: Duration = .seconds(1))
+        case fixed(max: Int, delay: Duration)
+        case immediate(max: Int)
+    }
+}
+
+enum RetryCondition: Sendable {
+    case serverError        // 500-599
+    case timeout            // URLError.timedOut
+    case connectionLost     // URLError.networkConnectionLost
+    case tooManyRequests    // 429
+    case statusCode(Int)    // specific code
+}
+```
+
+Factory methods:
+
+```swift
+RetryPolicy.exponential(max: 3)
+RetryPolicy.exponential(max: 3, on: [.serverError, .tooManyRequests])
+RetryPolicy.fixed(max: 5, delay: .seconds(2), on: [.tooManyRequests])
+```
+
+Default conditions: `[.serverError, .timeout, .connectionLost]`.
+
+## CachePolicy + CacheStorage + ByteCount
+
+```swift
+enum CachePolicy: Sendable {
+    case returnCacheElseLoad(ttl: Duration)
+    case reloadIgnoringCache
+    case returnCacheOnly
+}
+
+enum CacheStorage: Sendable {
+    case memory(limit: ByteCount)
+    case disk(directory: URL, limit: ByteCount)
+}
+
+struct ByteCount: Sendable {
+    var bytes: Int64
+
+    static func megabytes(_ mb: Int64) -> ByteCount
+    static func gigabytes(_ gb: Int64) -> ByteCount
+}
+```
+
+## Transfer + TransferProgress
+
+```swift
+struct Transfer<Value: Sendable>: Sendable {
+    var progress: AsyncStream<TransferProgress>
+    var value: Value { get async throws }
+}
+
+struct TransferProgress: Sendable {
+    var fractionCompleted: Double
+    var totalBytes: Int64?
+    var completedBytes: Int64
+}
+```
+
+Return type signals progress tracking. HTTP method determines direction:
+- GET/DELETE + `Transfer<T>` → download
+- POST/PUT/PATCH + `Transfer<T>` → upload
+
+No `@Download`/`@Upload` annotation needed.
+
+Usage:
+
+```swift
+// With progress:
+let transfer = api.files.download("large-file")
+Task { for await p in transfer.progress { updateBar(p.fractionCompleted) } }
+let data = try await transfer.value
+
+// Without progress:
+let data = try await api.files.download("large-file").value
+```
+
+## Pagination Utilities
+
+### Offset-based
+
+```swift
+func paginate<T>(
+    startingAt page: Int = 1,
+    _ fetch: @Sendable (Int) async throws -> PaginatedResponse<T>
+) -> AsyncThrowingStream<[T], any Error>
+
+protocol PaginatedResponse<Item> {
+    associatedtype Item
+    var items: [Item] { get }
+    var hasNextPage: Bool { get }
+}
+```
+
+### Cursor-based
+
+```swift
+func cursorPaginate<T>(
+    _ fetch: @Sendable (String?) async throws -> CursorPaginatedResponse<T>
+) -> AsyncThrowingStream<[T], any Error>
+
+protocol CursorPaginatedResponse<Item> {
+    associatedtype Item
+    var items: [Item] { get }
+    var nextCursor: String? { get }
+}
+```
+
+Usage:
+
+```swift
+for try await batch in paginate({ page in
+    try await api.users.list(page, 20)
+}) {
+    allUsers.append(contentsOf: batch)
+}
+```
+
+Users can always call endpoints manually for custom pagination logic.

--- a/docs/networking/specs/macros.md
+++ b/docs/networking/specs/macros.md
@@ -1,0 +1,154 @@
+# Macros
+
+## Inventory (24 total)
+
+### Core macros (generate code)
+- `@Client(base:)` — `@attached(extension)` — generates `init(network:)`
+- `@API` / `@API(networks:default:)` — `@attached(extension)` — generates container init
+- `@SSEEvents` — `@attached(extension)` — generates `SSEEventDecodable` conformance
+
+### Marker macros (metadata only — shared `MarkerMacro` implementation)
+- HTTP methods: `@GET`, `@POST`, `@PUT`, `@DELETE`, `@PATCH`, `@SSE`, `@WebSocket`
+- Annotations: `@Authenticated`, `@Idempotent`, `@Deduplicate`
+- Config: `@Retry`, `@Cache`, `@Timeout`, `@Encoder`, `@Decoder`, `@ContentType`, `@Header`
+- Response: `@ValidStatus`, `@ResponseMapper`
+- Extensibility: `@Context`, `@Network`
+- SSE: `@Event`
+
+All marker macros share one implementation that returns empty. They exist only as metadata for `@Client`, `@API`, and `@SSEEvents` to read from the syntax tree.
+
+## @Client Implementation
+
+**Role:** `@attached(extension, names: named(init))`
+
+### What it reads
+
+1. `base` argument from `@Client(base: "/users")`
+2. Each `var` member with an HTTP method attribute
+3. Per member: HTTP method + path, all annotation attributes, closure type signature
+
+### What it generates
+
+An extension with `init(network: NetworkClient)`:
+
+```swift
+extension UserClient {
+    init(network: NetworkClient) {
+        self.init(
+            getUser: { id in
+                try await network.send(
+                    Request.get("/users/\(id)")
+                        .authenticated(),
+                    as: User.self
+                )
+            },
+            createUser: { body in
+                try await network.send(
+                    Request.post("/users")
+                        .header(.contentType, ContentType.applicationJSON.rawValue)
+                        .body(try network.defaultEncoder.encode(body))
+                        .authenticated(),
+                    as: User.self
+                )
+            }
+        )
+    }
+}
+```
+
+### Generation rules
+
+**Path construction:** Combine base + endpoint path, interpolate path parameters.
+
+**Body encoding by content type/body type:**
+- Default `Encodable` → `network.defaultEncoder.encode(body)` + JSON content type
+- `@ContentType(.formURLEncoded)` → `FormURLEncoder().encode(body)`
+- `@Encoder(Custom.self)` → `Custom().encode(body)`
+- `MultipartFormData` body type → `body.encoded()` + `body.contentType` (auto-detected)
+- `String` body with `@ContentType(.text)` → `Data(body.utf8)`
+- `Data` body with `@ContentType(.octetStream)` → raw Data
+
+**Network method by return type:**
+- `async throws -> T` → `network.send(request, as: T.self)`
+- `async throws -> T?` → `network.send(request, as: T?.self)`
+- `async throws -> Void` → `network.send(request)`
+- `async throws -> Data` → `network.data(request)`
+- `async throws -> String` → `network.string(request)`
+- `-> AsyncThrowingStream<T, Error>` → `network.stream(request, as: T.self)`
+- `-> Transfer<T>` → `network.transfer(request, as: T.self)`
+
+**Annotations → builder calls:** The macro reads annotation syntax and re-emits as builder method calls. It doesn't interpret the arguments — the compiler type-checks the generated code.
+
+## @API Implementation
+
+**Role:** `@attached(extension, names: named(init))`
+
+**Simple form:** Generates `init(network: NetworkClient)`:
+```swift
+extension AppAPI {
+    init(network: NetworkClient) {
+        self.init(
+            users: UserClient(network: network),
+            posts: PostClient(network: network)
+        )
+    }
+}
+```
+
+**Multi-network form:** Reads `networks:` type and `default:` key path. `@Network(\.key)` overrides per property:
+```swift
+extension AppAPI {
+    init(networks: AppNetworks) {
+        self.init(
+            users: UserClient(network: networks.main),      // default
+            auth: AuthClient(network: networks.auth),        // @Network(\.auth)
+            uploads: UploadClient(network: networks.cdn)     // @Network(\.cdn)
+        )
+    }
+}
+```
+
+Properties with default values are skipped.
+
+## @SSEEvents Implementation
+
+**Role:** `@attached(extension, names: named(init))`
+
+Generates `SSEEventDecodable` conformance from enum with `@Event` annotations. See `sse.md`.
+
+## Path Validation (compile-time)
+
+### @Client(base:)
+- Must start with `/`
+- No trailing slash (stripped with warning)
+- No spaces or invalid URL characters
+- No query string
+- No placeholders
+
+### @GET(path) etc.
+- Must start with `/` (default `/` when omitted)
+- `{placeholder}` names must be valid Swift identifiers
+- No unclosed/nested braces
+- No spaces
+- No query string
+
+## Error Diagnostics
+
+| Scenario | Severity | Message |
+|---|---|---|
+| Multiple HTTP methods on one var | Error | Multiple HTTP method annotations on '{name}'. Use exactly one. |
+| Path `{userId}` with no matching param | Error | Path parameter '{userId}' has no matching parameter. Found 'id' — did you mean '{id}'? |
+| Unnamed closure params `(String)` | Error | Closure parameters must have names. Use: (_ id: String) |
+| `@Client` on class/enum | Error | @Client can only be applied to structs. |
+| `@Client(base: "")` | Error | Base path cannot be empty. |
+| `@SSE` without `AsyncThrowingStream` return | Error | @SSE requires return type AsyncThrowingStream<T, Error>. |
+| Non-closure type with HTTP annotation | Error | Endpoint '{name}' must have a closure type. |
+| Computed property with HTTP annotation | Error | Endpoint '{name}' must be a stored property. |
+| `@Network` without `@API(networks:)` | Error | @Network requires @API with 'networks' parameter. |
+| `@API(networks:)` without `default:` | Error | @API with 'networks' requires 'default' parameter. |
+| Annotations without HTTP method | Warning | Property '{name}' has annotations but no HTTP method. |
+| `let` endpoint | Warning | Endpoint '{name}' is 'let'. Use 'var' for mock overrides. |
+| GET with body param | Warning | GET request with 'body' parameter is uncommon. |
+| `@ValidStatus(404)` on non-optional | Warning | @ValidStatus(404) on non-optional '{Type}': 404 will throw if body can't be decoded. Did you mean '{Type}?'? |
+| Complex type not named body on POST | Warning | Complex type '{Type}' on POST will be encoded as query params. If this should be the body, rename to 'body'. |
+| Base path missing leading `/` | Warning | Base path should start with '/'. Interpreting as '/{path}'. |

--- a/docs/networking/specs/middleware.md
+++ b/docs/networking/specs/middleware.md
@@ -1,0 +1,176 @@
+# Middleware
+
+## Protocol
+
+```swift
+protocol Middleware: Sendable {
+    func intercept(
+        request: Request,
+        next: @Sendable (Request) async throws -> Response
+    ) async throws -> Response
+}
+```
+
+Onion pattern: everything before `next()` runs on the request path, everything after runs on the response path (reverse order).
+
+```swift
+struct AuthMiddleware: Middleware {
+    var tokenProvider: @Sendable () async throws -> String
+
+    func intercept(
+        request: Request,
+        next: @Sendable (Request) async throws -> Response
+    ) async throws -> Response {
+        guard request.metadata.requiresAuth else {
+            return try await next(request)
+        }
+        let token = try await tokenProvider()
+        return try await next(
+            request.header(.authorization, "Bearer \(token)")
+        )
+    }
+}
+```
+
+## Execution Order
+
+```swift
+NetworkClient(baseURL: "...") {
+    Logger()         // 1st to see request, last to see response
+    Authenticate {}  // 2nd
+    Retry()          // 3rd — wraps in retry
+    Cache()          // 4th — closest to transport
+}
+```
+
+```
+Request  → Logger → Authenticate → Retry → Cache → Transport
+Response ← Logger ← Authenticate ← Retry ← Cache ←
+```
+
+## MiddlewareGroup
+
+Compose middleware into reusable groups (SwiftUI-style):
+
+```swift
+protocol MiddlewareGroup: Middleware {
+    @MiddlewareBuilder
+    var body: [any Middleware] { get }
+}
+```
+
+Default `intercept` implementation chains through all middleware in `body`.
+
+```swift
+struct AuthenticatedMiddleware: MiddlewareGroup {
+    var tokenStore: TokenStore
+
+    var body: [any Middleware] {
+        Logger()
+        Authenticate { try await tokenStore.current }
+        Retry(.exponential(max: 3))
+    }
+}
+```
+
+Groups nest freely:
+
+```swift
+NetworkClient(baseURL: "...") {
+    AuthenticatedMiddleware(tokenStore: tokenStore)
+    Cache(storage: .memory(limit: .megabytes(50)))
+}
+```
+
+## MiddlewareBuilder
+
+Result builder supporting conditionals and loops:
+
+```swift
+@resultBuilder
+struct MiddlewareBuilder {
+    static func buildBlock(_ components: any Middleware...) -> [any Middleware]
+    static func buildOptional(_ component: [any Middleware]?) -> [any Middleware]
+    static func buildEither(first component: [any Middleware]) -> [any Middleware]
+    static func buildEither(second component: [any Middleware]) -> [any Middleware]
+    static func buildArray(_ components: [[any Middleware]]) -> [any Middleware]
+}
+```
+
+```swift
+NetworkClient(baseURL: "...") {
+    Logger()
+    if useAuth {
+        Authenticate { ... }
+    }
+    Retry()
+}
+```
+
+## Inline Helpers
+
+### Intercept — full control
+
+```swift
+Intercept { request, next in
+    let start = ContinuousClock.now
+    let response = try await next(request)
+    print("Duration: \(start.elapsed)")
+    return response
+}
+```
+
+### MapRequest — modify request before sending
+
+```swift
+MapRequest { request in
+    request
+        .header(.custom("X-App-Version"), Bundle.main.appVersion)
+        .header(.custom("X-Platform"), "iOS")
+}
+```
+
+### MapResponse — modify response after receiving
+
+```swift
+MapResponse { response in
+    var response = response
+    // envelope unwrapping
+    if let inner = try? JSONSerialization.jsonObject(with: response.body) as? [String: Any],
+       let data = inner["data"] {
+        response.body = try JSONSerialization.data(withJSONObject: data)
+    }
+    return response
+}
+```
+
+### OnContext — act on a specific metadata key
+
+```swift
+OnContext(\.rateLimit) { limit, request in
+    await rateLimiter.acquire(limit: limit)
+    return request
+}
+```
+
+Only executes when the key has a value. For optional metadata keys from `@Context`.
+
+## Built-in Middleware
+
+| Middleware | Configuration | Reads from metadata |
+|---|---|---|
+| `Logger(level:, logBody:, redactHeaders:)` | Verbose mode available | — |
+| `Authenticate(provider:, refreshOn:, refresh:)` | Bearer token, refresh flow | `requiresAuth` |
+| `Retry(defaultPolicy:)` | Exponential/fixed/immediate | `retryPolicy`, `idempotent` |
+| `Cache(storage:)` | Memory or disk, ETag support | `cachePolicy` |
+| `Timeout(default:)` | Per-request override | `timeout` |
+| `Deduplicate(scope:, ttl:)` | GET-only by default | `deduplicate` |
+
+## Annotations → Metadata → Middleware
+
+Annotations set metadata tags on Request. Middleware reads them. Clean separation — annotations describe characteristics, middleware decides behavior.
+
+```
+@Authenticated  →  metadata.requiresAuth = true  →  Authenticate middleware adds token
+@Retry(...)     →  metadata.retryPolicy = ...     →  Retry middleware wraps in retry
+```

--- a/docs/networking/specs/network-client.md
+++ b/docs/networking/specs/network-client.md
@@ -1,0 +1,116 @@
+# NetworkClient
+
+The central type that holds configuration, chains middleware, and sends requests.
+
+## Shape
+
+```swift
+struct NetworkClient: Sendable {
+    var baseURL: String
+    var middleware: [any Middleware]
+    var transport: any Transport
+    var defaultHeaders: [String: String]
+    var defaultDecoder: any ResponseDecoding
+    var defaultEncoder: any RequestEncoding
+    var defaultResponseMapper: (any ResponseMapping.Type)?
+}
+```
+
+Struct (value type). Middleware instances can hold reference-type state (actors for deduplication, caches) — copying the array is cheap.
+
+## Construction
+
+Result builder for middleware, modifier chain for configuration:
+
+```swift
+let network = NetworkClient(baseURL: "https://api.example.com") {
+    Logger()
+    Authenticate { try await tokenStore.current }
+    Retry(.exponential(max: 3))
+}
+.defaultHeaders([.accept: "application/json", .userAgent: "MyApp/1.0"])
+.defaultDecoder(JSONDecoder())
+.defaultEncoder(JSONEncoder())
+.responseMapper(EnvelopeUnwrapper.self)
+```
+
+Sensible defaults (JSON, no middleware, URLSession transport):
+
+```swift
+let network = NetworkClient(baseURL: "https://api.example.com")
+```
+
+Modifier chain returns new NetworkClient (immutable, functional style).
+
+## Send Methods
+
+| Method | Returns | Use case |
+|---|---|---|
+| `send<T: Decodable>(Request, as: T.Type)` | `T` | Decodable response |
+| `send(Request)` | `Void` | No response body |
+| `data(Request)` | `Data` | Raw bytes |
+| `string(Request)` | `String` | UTF-8 text |
+| `stream<T: Decodable>(Request, as: T.Type)` | `AsyncThrowingStream<T, Error>` | SSE |
+| `transfer<T: Decodable>(Request, as: T.Type)` | `Transfer<T>` | Progress tracking |
+
+The macro picks the method based on the endpoint's return type.
+
+## Internal Flow
+
+Every send method follows the same pipeline:
+
+```
+1. Apply default headers (request headers take precedence over defaults)
+2. Run middleware chain (onion pattern)
+3. Transport converts Request → URLRequest, sends, returns Response
+4. Validate status code (metadata.validStatuses ?? 200...299)
+5. Apply response mapper (metadata.responseMapper ?? defaultResponseMapper)
+6. Decode body (metadata.decoder ?? defaultDecoder)
+7. Return decoded value
+```
+
+### Special Type Handling
+
+| Type | Step 6 behavior |
+|---|---|
+| `T: Decodable` | Decode using configured decoder |
+| `T?` (Optional) | Try decode; if body is empty or decoding fails on valid status → return nil |
+| `Void` | Skip decoding |
+| `Data` | Return raw body |
+| `String` | Decode body as UTF-8 |
+
+### SSE Stream
+
+`stream()` uses a different transport method:
+
+```
+1. Apply default headers + middleware (initial HTTP request)
+2. transport.bytes(urlRequest) → AsyncBytes
+3. SSEParser.events(from: bytes) → ServerSentEvent stream
+4. Decode or route (SSEEventDecodable or plain Decodable)
+5. Auto-reconnect with Last-Event-ID on disconnect
+```
+
+### Transfer (Progress)
+
+`transfer()` uses progress-capable transport:
+
+```
+1. Apply default headers + middleware (initial HTTP request)
+2. transport.upload/download(urlRequest) → TransportTask
+3. Wrap into Transfer<T>(progress: ..., value: { validate + decode })
+```
+
+## Multiple Networks
+
+Different backends use separate NetworkClient instances:
+
+```swift
+struct AppNetworks {
+    let main: NetworkClient
+    let auth: NetworkClient
+    let cdn: NetworkClient
+}
+```
+
+The `@API` container wires clients to their networks. See `public-api.md`.

--- a/docs/networking/specs/overview.md
+++ b/docs/networking/specs/overview.md
@@ -1,0 +1,47 @@
+# Overview
+
+## Project
+
+A modern Swift networking library with macro-powered API definitions, structured concurrency, and a composable middleware system.
+
+- **Repository:** swift-networking
+- **Module name:** Networking
+- **Personal use + open source**
+
+## Platform Targets
+
+- Apple-only for v1: iOS 16+, macOS 13+, watchOS 9+, tvOS 16+, visionOS 1+
+- Transport protocol enables future Linux/SwiftNIO support without redesign
+
+## Swift Version
+
+- Swift 6 strict concurrency from day one
+- All types are `Sendable`
+
+## Module Structure
+
+```
+Sources/
+├── Networking/           # Core + SSE + macro declarations
+├── NetworkingMacros/     # .macro target (SwiftSyntax)
+└── NetworkingWebSocket/  # WebSocket
+Tests/
+├── NetworkingTests/
+├── NetworkingMacroTests/
+└── NetworkingWebSocketTests/
+```
+
+- **Networking:** Core types (Request, Response, NetworkClient, Middleware, Transport, errors), SSE support, and macro declarations. Zero runtime external dependencies.
+- **NetworkingMacros:** Macro implementations using SwiftSyntax. Compile-time only — not shipped in consumer binaries.
+- **NetworkingWebSocket:** WebSocket support. Separate module because it's a different protocol with its own connection lifecycle.
+
+SSE lives in core because it's HTTP streaming with text parsing — thin enough to include, and `NetworkClient.stream()` needs to be accessible from macro-generated code without extra imports.
+
+## Future Modules (separate repositories)
+
+- `swift-graphql` — GraphQL support, depends on Networking
+- `swift-grpc` — gRPC support, depends on Networking
+
+## Library Usable Without Macros
+
+Core types (NetworkClient, Request, Response, Middleware, RequestMetadata) work standalone. Users can write `init(network:)` by hand. Macros are sugar, not a requirement.

--- a/docs/networking/specs/package.md
+++ b/docs/networking/specs/package.md
@@ -1,0 +1,90 @@
+# Package.swift
+
+## Configuration
+
+- **swift-tools-version:** 6.0
+- **Package name:** swift-networking
+
+## Platforms
+
+```swift
+platforms: [
+    .iOS(.v16),
+    .macOS(.v13),
+    .watchOS(.v9),
+    .tvOS(.v16),
+    .visionOS(.v1),
+]
+```
+
+## Products
+
+```swift
+products: [
+    .library(name: "Networking", targets: ["Networking"]),
+    .library(name: "NetworkingWebSocket", targets: ["NetworkingWebSocket"]),
+]
+```
+
+Two products. Most users only import `Networking`.
+
+## Dependencies
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
+]
+```
+
+SwiftSyntax is compile-time only (used by the macro target). Zero runtime external dependencies.
+
+## Targets
+
+```swift
+// Core + SSE + macro declarations
+.target(name: "Networking", dependencies: ["NetworkingMacros"])
+
+// Macro implementations
+.macro(name: "NetworkingMacros", dependencies: [
+    .product(name: "SwiftSyntax", package: "swift-syntax"),
+    .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+    .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+])
+
+// WebSocket
+.target(name: "NetworkingWebSocket", dependencies: ["Networking"])
+```
+
+## Test Targets
+
+```swift
+.testTarget(name: "NetworkingTests", dependencies: ["Networking"])
+
+.testTarget(name: "NetworkingMacroTests", dependencies: [
+    "NetworkingMacros",
+    .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+])
+
+.testTarget(name: "NetworkingWebSocketTests", dependencies: ["NetworkingWebSocket"])
+```
+
+## Dependency Graph
+
+```
+Consumer app
+├── import Networking           → Networking target
+│   └── depends on               NetworkingMacros (compile-time only)
+│       └── depends on            SwiftSyntax
+└── import NetworkingWebSocket  → NetworkingWebSocket target (optional)
+    └── depends on               Networking
+```
+
+SwiftSyntax does NOT ship in the consumer's binary.
+
+## Summary
+
+- 2 products
+- 3 source targets
+- 3 test targets
+- 1 external dependency (compile-time only)
+- 0 runtime external dependencies

--- a/docs/networking/specs/public-api.md
+++ b/docs/networking/specs/public-api.md
@@ -1,0 +1,112 @@
+# Public API
+
+## Closure-Based Client Pattern
+
+The primary API is struct-with-closures, inspired by Point-Free's Dependencies pattern. Each API client is a struct with closure properties. Macros generate the live implementation.
+
+```swift
+@Client(base: "/users")
+struct UserClient {
+    @GET("/{id}")
+    @Authenticated
+    var getUser: @Sendable (_ id: String) async throws -> User
+
+    @POST
+    @Authenticated
+    var createUser: @Sendable (_ body: CreateUserRequest) async throws -> User
+
+    @DELETE("/{id}")
+    @Authenticated
+    @Idempotent
+    var deleteUser: @Sendable (_ id: String) async throws -> Void
+}
+```
+
+### Macro Generation
+
+`@Client` generates `init(network: NetworkClient)` in an extension, preserving Swift's memberwise init for testing:
+
+```swift
+// Live usage:
+let users = UserClient(network: network)
+let user = try await users.getUser("123")
+
+// Test usage (memberwise init):
+let mock = UserClient(
+    getUser: { _ in User(id: "1", name: "Test") },
+    createUser: { _ in fatalError() },
+    deleteUser: { _ in fatalError() }
+)
+```
+
+## Parameter Inference Rules
+
+Three rules, applied in order:
+
+1. **Name matches `{placeholder}` in path** → Path parameter
+2. **Name is `body`** → Request body
+3. **Everything else** → Query parameter
+
+Query parameter details:
+- Primitive types (Int, String, Bool, Double) → encoded directly
+- Optional → omitted when nil
+- Array → encoded per QueryEncoder strategy
+- Complex type (Encodable struct) → flattened via QueryEncoder
+
+## Return Type → Behavior
+
+| Return Type | Behavior |
+|---|---|
+| `async throws -> T` (Decodable) | Single request, decode JSON response |
+| `async throws -> T?` | Nilable (with @ValidStatus for 404 → nil) |
+| `async throws -> Void` | Validate status, skip decoding |
+| `async throws -> Data` | Validate status, return raw bytes |
+| `async throws -> String` | Validate status, decode as UTF-8 |
+| `-> AsyncThrowingStream<T, Error>` | SSE streaming |
+| `-> Transfer<T>` | Upload/download with progress |
+
+## @API Container
+
+Groups multiple clients with optional multi-network support:
+
+```swift
+// Single network:
+@API
+struct AppAPI {
+    var users: UserClient
+    var posts: PostClient
+}
+let api = AppAPI(network: network)
+
+// Multiple networks:
+@API(networks: AppNetworks.self, default: \.main)
+struct AppAPI {
+    var users: UserClient
+    @Network(\.auth) var auth: AuthClient
+    @Network(\.cdn) var uploads: UploadClient
+}
+let api = AppAPI(networks: appNetworks)
+```
+
+Properties with default values are skipped (not treated as clients). Both forms preserve the memberwise init for manual wiring.
+
+## NetworkClient Configuration
+
+```swift
+let network = NetworkClient(baseURL: "https://api.example.com") {
+    Logger()
+    Authenticate { try await tokenStore.current }
+    Retry(.exponential(max: 3))
+    Cache(storage: .memory(limit: .megabytes(50)))
+}
+.defaultHeaders([.accept: "application/json", .userAgent: "MyApp/1.0"])
+.defaultDecoder(JSONDecoder())
+.defaultEncoder(JSONEncoder())
+.responseMapper(EnvelopeUnwrapper.self)
+```
+
+Sensible defaults: JSON encoder/decoder, URLSession transport, no middleware. Minimal construction for simple cases:
+
+```swift
+let network = NetworkClient(baseURL: "https://api.example.com")
+```

--- a/docs/networking/specs/request-metadata.md
+++ b/docs/networking/specs/request-metadata.md
@@ -1,0 +1,100 @@
+# RequestMetadata
+
+Extensible key-value store for per-endpoint configuration. Same pattern as SwiftUI's `EnvironmentValues`.
+
+## Design
+
+Pure key-value storage — all keys (built-in and custom) use the same mechanism:
+
+```swift
+struct RequestMetadata: Sendable {
+    private var storage: [ObjectIdentifier: any Sendable] = [:]
+
+    subscript<K: RequestMetadataKey>(key: K.Type) -> K.Value {
+        get { storage[ObjectIdentifier(key)] as? K.Value ?? K.defaultValue }
+        set { storage[ObjectIdentifier(key)] = newValue }
+    }
+}
+
+protocol RequestMetadataKey {
+    associatedtype Value: Sendable
+    static var defaultValue: Value { get }
+}
+```
+
+## Built-in Keys
+
+Exposed as computed properties on `RequestMetadata`:
+
+| Property | Type | Default | Set by |
+|---|---|---|---|
+| `requiresAuth` | `Bool` | `false` | `@Authenticated` |
+| `retryPolicy` | `RetryPolicy?` | `nil` | `@Retry` |
+| `timeout` | `TimeInterval?` | `nil` | `@Timeout` |
+| `idempotent` | `Bool?` | `nil` | `@Idempotent` |
+| `deduplicate` | `Bool` | `false` | `@Deduplicate` |
+| `cachePolicy` | `CachePolicy?` | `nil` | `@Cache` |
+| `validStatuses` | `Set<Int>?` | `nil` | `@ValidStatus` |
+| `decoder` | `(any ResponseDecoding.Type)?` | `nil` | `@Decoder` |
+| `responseMapper` | `(any ResponseMapping.Type)?` | `nil` | `@ResponseMapper` |
+
+When `nil`, NetworkClient falls back to its own defaults.
+
+Each built-in key follows the pattern:
+
+```swift
+enum RequiresAuthKey: RequestMetadataKey {
+    static var defaultValue: Bool { false }
+}
+
+extension RequestMetadata {
+    var requiresAuth: Bool {
+        get { self[RequiresAuthKey.self] }
+        set { self[RequiresAuthKey.self] = newValue }
+    }
+}
+```
+
+## User Extension
+
+Users extend RequestMetadata with custom keys:
+
+```swift
+// 1. Define a key:
+enum RateLimitKey: RequestMetadataKey {
+    static var defaultValue: Int? { nil }
+}
+
+// 2. Add computed property:
+extension RequestMetadata {
+    var rateLimit: Int? {
+        get { self[RateLimitKey.self] }
+        set { self[RateLimitKey.self] = newValue }
+    }
+}
+
+// 3. Use via @Context annotation:
+@GET("/search")
+@Context(\.rateLimit, 10)
+var search: @Sendable (_ query: String) async throws -> SearchResult
+
+// 4. Read in middleware:
+OnContext(\.rateLimit) { limit, request in
+    await rateLimiter.acquire(limit: limit)
+    return request
+}
+```
+
+## Request Builder Integration
+
+Metadata is set through builder methods on Request, not constructed directly:
+
+```swift
+Request.get("/users/123")
+    .authenticated()                      // metadata.requiresAuth = true
+    .retry(.exponential(max: 3))          // metadata.retryPolicy = ...
+    .timeout(30)                          // metadata.timeout = 30
+    .context(\.rateLimit, 10)             // metadata[RateLimitKey.self] = 10
+```
+
+Users never construct RequestMetadata directly — it's an implementation detail behind the Request builder.

--- a/docs/networking/specs/request-response.md
+++ b/docs/networking/specs/request-response.md
@@ -1,0 +1,103 @@
+# Request & Response
+
+## Request
+
+```swift
+struct Request: Sendable {
+    var method: HTTPMethod
+    var path: String
+    var headers: [String: String] = [:]
+    var query: [URLQueryItem] = []
+    var body: Data? = nil
+    var metadata: RequestMetadata = RequestMetadata()
+}
+```
+
+- **path:** Relative path only (e.g., "/users/123"). Macro combines `@Client(base:)` + endpoint path. `NetworkClient` prepends `baseURL`.
+- **headers:** `[String: String]` with `HeaderKey` subscript for common headers.
+- **query:** `[URLQueryItem]` — already encoded by the time Request is created. Optional params omitted when nil.
+- **body:** `Data?` — pre-encoded by macro using configured encoder. `nil` means no body.
+- **metadata:** Extensible key-value store for middleware tags. See `request-metadata.md`.
+
+### Builder Pattern
+
+Static factories:
+
+```swift
+Request.get("/users/123")
+Request.post("/users")
+Request.put("/users/123")
+Request.delete("/users/123")
+Request.patch("/users/123")
+```
+
+Modifier chain (each returns a new Request):
+
+```swift
+Request.post("/users")
+    .header(.contentType, ContentType.applicationJSON.rawValue)
+    .header(.custom("X-API-Version"), "2")
+    .query("notify", "true")
+    .query(encodedItems)            // [URLQueryItem]
+    .body(encodedData)
+    .contentType(.applicationJSON)
+    .authenticated()
+    .retry(.exponential(max: 3), on: [.serverError])
+    .timeout(30)
+    .idempotent()
+    .deduplicate()
+    .validStatus(200, 404)
+    .decoder(CustomDecoder.self)
+    .responseMapper(LegacyMapper.self)
+    .context(\.rateLimit, 10)
+```
+
+Metadata shortcuts (`.authenticated()`, `.retry()`, etc.) set values on `request.metadata` internally.
+
+Var properties are also available for middleware mutation.
+
+### HeaderKey Subscript
+
+```swift
+request[header: .authorization] = "Bearer token"   // set
+let value = request[header: .accept]                // get
+request.headers["X-Custom"] = "value"               // raw string
+```
+
+### Path Defaults
+
+`@GET`, `@POST`, etc. default path to `"/"` when omitted. `@Client(base:)` is required.
+
+## Response
+
+```swift
+struct Response: Sendable {
+    var statusCode: Int
+    let headers: [String: String]
+    var body: Data
+
+    var isSuccess: Bool { (200...299).contains(statusCode) }
+    var isRedirect: Bool { (300...399).contains(statusCode) }
+    var isClientError: Bool { (400...499).contains(statusCode) }
+    var isServerError: Bool { (500...599).contains(statusCode) }
+
+    subscript(header key: HeaderKey) -> String? {
+        headers[key.rawValue]
+    }
+}
+```
+
+- **headers:** `let` — signals read-only. Middleware should not modify response headers. To modify (rare), create a new Response explicitly.
+- **body:** `var` — `MapResponse` middleware can transform the body (e.g., envelope unwrapping).
+- **body is `Data`, not `Data?`:** Even empty responses (204) have `Data()`. Decoders handle empty data based on return type.
+
+Response is converted from `(Data, URLResponse)` by NetworkClient after transport returns.
+
+## What Request/Response Do NOT Carry
+
+| Concern | Where it lives |
+|---|---|
+| Base URL | `NetworkClient.baseURL` |
+| Default encoder/decoder | `NetworkClient` config |
+| Response decoded type | Generic parameter on `NetworkClient.send<T>()` |
+| Redirect history | URLSession handles this |

--- a/docs/networking/specs/sse.md
+++ b/docs/networking/specs/sse.md
@@ -1,0 +1,161 @@
+# Server-Sent Events (SSE)
+
+Lives in core Networking module (not separate). SSE is HTTP streaming with text parsing — thin enough to include, and `NetworkClient.stream()` needs to be accessible from macro-generated code.
+
+## ServerSentEvent
+
+```swift
+struct ServerSentEvent: Sendable {
+    var event: String?    // event type, nil means "message"
+    var data: String      // payload (can be multi-line)
+    var id: String?       // event ID for reconnection
+    var retry: Int?       // reconnection delay in ms
+}
+```
+
+Public type. Users who need raw event access use `ServerSentEvent` as the stream type.
+
+## SSEParser
+
+Consumes `URLSession.AsyncBytes`, parses per SSE spec, emits events:
+
+```swift
+struct SSEParser {
+    static func events(from bytes: URLSession.AsyncBytes) -> AsyncThrowingStream<ServerSentEvent, Error>
+}
+```
+
+Parsing rules (per spec):
+- Lines starting with `:` → comments, skip
+- `field: value` → accumulate into current event
+- `data:` can appear multiple times → join with `\n`
+- Blank line → emit current event, reset
+- Unknown fields → ignore
+
+## Reconnection
+
+Auto-reconnect on disconnect (on by default):
+
+```swift
+func stream<T: Decodable>(
+    _ request: Request,
+    as type: T.Type,
+    event: String? = nil,
+    reconnect: Bool = true
+) -> AsyncThrowingStream<T, Error>
+```
+
+Reconnection loop:
+1. Connect with `Last-Event-ID` header (if available)
+2. Stream events, track `lastEventID` and `retryDelay`
+3. On disconnect: if `reconnect` is true, wait `retryDelay` (default 3s), loop
+4. Consumer sees continuous stream — reconnection is invisible
+5. Cancel by cancelling the Task or breaking out of the for loop
+
+## Event Filtering
+
+`event:` parameter filters to specific event type:
+
+```swift
+// All events:
+@SSE("/events")
+var stream: @Sendable () -> AsyncThrowingStream<Message, Error>
+
+// Filtered to "message" events only:
+@SSE("/events", event: "message")
+var messages: @Sendable () -> AsyncThrowingStream<Message, Error>
+
+// With enum for type safety:
+@SSE("/events", event: EventType.message)
+var messages: @Sendable () -> AsyncThrowingStream<Message, Error>
+```
+
+`stream()` accepts both `String` and `RawRepresentable<String>` for the `event` parameter.
+
+## SSEEventDecodable
+
+For multi-event-type streams where different events have different payload types:
+
+```swift
+protocol SSEEventDecodable: Sendable {
+    init?(event: String, data: Data) throws
+}
+```
+
+When `T: SSEEventDecodable`, `stream()` uses `T.init(event:data:)` instead of plain JSON decoding. Events returning `nil` (unknown types) are skipped.
+
+When `T: Decodable` (not SSEEventDecodable), all events are decoded as `T`.
+
+When `T == ServerSentEvent`, raw events are returned without decoding.
+
+## @SSEEvents Macro
+
+Generates `SSEEventDecodable` conformance from an annotated enum:
+
+```swift
+@SSEEvents
+enum FeedEvent {
+    @Event("message") case message(Message)         // has payload
+    @Event("user_joined") case userJoined(UserEvent) // has payload
+    @Event("heartbeat") case heartbeat               // no payload
+}
+```
+
+Generates:
+
+```swift
+extension FeedEvent: SSEEventDecodable {
+    init?(event: String, data: Data) throws {
+        let decoder = JSONDecoder()
+        switch event {
+        case "message":
+            self = .message(try decoder.decode(Message.self, from: data))
+        case "user_joined":
+            self = .userJoined(try decoder.decode(UserEvent.self, from: data))
+        case "heartbeat":
+            self = .heartbeat
+        default:
+            return nil
+        }
+    }
+}
+```
+
+Cases with associated values → decode. Cases without → construct directly.
+
+## Full Usage
+
+```swift
+// Define events:
+@SSEEvents
+enum FeedEvent {
+    @Event("message") case message(Message)
+    @Event("user_joined") case userJoined(UserEvent)
+    @Event("heartbeat") case heartbeat
+}
+
+// Define client:
+@Client(base: "/feed")
+struct FeedClient {
+    @SSE("/events")
+    @Authenticated
+    var stream: @Sendable () -> AsyncThrowingStream<FeedEvent, Error>
+
+    @SSE("/events", event: "message")
+    @Authenticated
+    var messages: @Sendable () -> AsyncThrowingStream<Message, Error>
+
+    @SSE("/events/{channel}")
+    @Authenticated
+    var channelStream: @Sendable (_ channel: String) -> AsyncThrowingStream<FeedEvent, Error>
+}
+
+// Use:
+for try await event in api.feed.stream() {
+    switch event {
+    case .message(let msg): showMessage(msg)
+    case .userJoined(let user): showBanner(user)
+    case .heartbeat: resetTimeout()
+    }
+}
+```

--- a/docs/networking/specs/transport.md
+++ b/docs/networking/specs/transport.md
@@ -1,0 +1,96 @@
+# Transport
+
+Abstraction over URLSession. NetworkClient calls Transport after the middleware chain. Transport has no knowledge of Request, Response, or RequestMetadata — it works with Foundation types only.
+
+## Protocol
+
+```swift
+protocol Transport: Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, URLResponse)
+    func bytes(_ request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse)
+    func upload(_ request: URLRequest, from data: Data) -> TransportTask
+    func download(_ request: URLRequest) -> TransportTask
+}
+```
+
+## TransportTask
+
+For progress-tracked uploads and downloads:
+
+```swift
+struct TransportTask: Sendable {
+    var progress: AsyncStream<TransferProgress>
+    var response: (Data, URLResponse) { get async throws }
+}
+
+struct TransferProgress: Sendable {
+    var fractionCompleted: Double
+    var totalBytes: Int64?
+    var completedBytes: Int64
+}
+```
+
+Progress and result are separate properties. Caller chooses what to observe:
+
+```swift
+// With progress:
+for await p in task.progress { updateBar(p.fractionCompleted) }
+let (data, response) = try await task.response
+
+// Without progress:
+let (data, response) = try await task.response
+```
+
+## URLSession Conformance
+
+`send` and `bytes` wrap existing URLSession async methods:
+
+```swift
+extension URLSession: Transport {
+    func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: request)
+    }
+
+    func bytes(_ request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse) {
+        try await bytes(for: request)
+    }
+}
+```
+
+`upload` and `download` bridge URLSession delegate callbacks into `TransportTask`. This requires an internal delegate wrapper that converts progress updates into the `AsyncStream`.
+
+## Conversion Layer
+
+NetworkClient converts between library types and Foundation types:
+
+```
+Request (our type)
+    │
+    ▼ NetworkClient converts
+URLRequest (Foundation)
+    │  - baseURL + path → URL
+    │  - headers → allHTTPHeaderFields
+    │  - query → URL query string
+    │  - body → httpBody
+    │  - method → httpMethod
+    │
+    ▼ Transport sends
+(Data, URLResponse) (Foundation)
+    │
+    ▼ NetworkClient converts
+Response (our type)
+    │  - statusCode from HTTPURLResponse
+    │  - headers from allHeaderFields
+    │  - body from Data
+```
+
+## Why Our Own Transport Protocol
+
+- `URLSession` doesn't bundle body with response — they're separate return values
+- `URLResponse` headers are `[AnyHashable: Any]`, not `[String: String]`
+- Decouples the library from Foundation for future SwiftNIO support
+- Easy to mock in tests — implement Transport with canned responses
+
+## Future: SwiftNIO
+
+For Linux support, a `SwiftNIOTransport` would conform to the same protocol. The library's public API stays identical — only the transport layer changes.

--- a/docs/networking/specs/websocket.md
+++ b/docs/networking/specs/websocket.md
@@ -1,0 +1,145 @@
+# WebSocket
+
+Lives in `NetworkingWebSocket` module. Separate because WebSocket is a different protocol with its own connection lifecycle, bidirectional communication, and uses `URLSessionWebSocketTask`.
+
+## WebSocketMessage
+
+```swift
+enum WebSocketMessage: Sendable {
+    case text(String)
+    case data(Data)
+}
+```
+
+## WebSocketCloseCode
+
+```swift
+enum WebSocketCloseCode: Sendable {
+    case normalClosure
+    case goingAway
+    case protocolError
+    case custom(Int)
+}
+```
+
+## WebSocketConnection
+
+Struct-with-closures for testability:
+
+```swift
+struct WebSocketConnection: Sendable {
+    var messages: AsyncThrowingStream<WebSocketMessage, Error>
+    var send: @Sendable (WebSocketMessage) async throws -> Void
+    var close: @Sendable (WebSocketCloseCode) async -> Void
+}
+```
+
+Testable:
+
+```swift
+let mock = WebSocketConnection(
+    messages: AsyncThrowingStream { continuation in
+        continuation.yield(.text("{\"text\": \"hello\"}"))
+        continuation.finish()
+    },
+    send: { message in /* assert */ },
+    close: { _ in }
+)
+```
+
+## Typed Send/Receive
+
+Convenience extensions for Codable messages:
+
+```swift
+extension WebSocketConnection {
+    func send<T: Encodable>(_ value: T, encoder: any RequestEncoding = JSONEncoder()) async throws
+
+    func messages<T: Decodable>(
+        as type: T.Type,
+        decoder: any ResponseDecoding = JSONDecoder()
+    ) -> AsyncThrowingStream<T, Error>
+}
+```
+
+## NetworkClient Integration
+
+`NetworkClient.webSocket()` is defined as an extension in the NetworkingWebSocket module:
+
+```swift
+// In NetworkingWebSocket:
+extension NetworkClient {
+    func webSocket(_ request: Request) async throws -> WebSocketConnection
+}
+```
+
+Users must `import NetworkingWebSocket` to use `@WebSocket` endpoints. If they forget, the compiler error is clear: `'NetworkClient' has no member 'webSocket'`.
+
+## Macro Integration
+
+```swift
+@Client(base: "/chat")
+struct ChatClient {
+    @WebSocket("/room/{roomId}")
+    @Authenticated
+    var joinRoom: @Sendable (_ roomId: String) async throws -> WebSocketConnection
+}
+```
+
+Macro generates:
+
+```swift
+joinRoom: { roomId in
+    try await network.webSocket(
+        Request.get("/chat/room/\(roomId)")
+            .authenticated()
+    )
+}
+```
+
+## No Auto-Reconnect
+
+Unlike SSE, WebSocket does NOT auto-reconnect:
+- WebSocket is bidirectional — reconnecting doesn't restore conversation state
+- The server may require re-authentication, room rejoining, etc.
+- Application logic determines whether and how to reconnect
+
+Consumer handles reconnection:
+
+```swift
+func connectToRoom(_ roomId: String) async {
+    while !Task.isCancelled {
+        do {
+            let connection = try await api.chat.joinRoom(roomId)
+            for try await message in connection.messages(as: ChatMessage.self) {
+                showMessage(message)
+            }
+        } catch {
+            try? await Task.sleep(for: .seconds(3))
+        }
+    }
+}
+```
+
+## Middleware
+
+Middleware applies to the initial HTTP upgrade request only (auth headers, logging the connection attempt). Once the WebSocket is established, messages bypass middleware.
+
+## Full Usage
+
+```swift
+let connection = try await api.chat.joinRoom("general")
+
+// Send typed:
+try await connection.send(ChatMessage(type: "message", text: "hello"))
+
+// Receive typed:
+Task {
+    for try await message in connection.messages(as: ChatMessage.self) {
+        showMessage(message)
+    }
+}
+
+// Close:
+await connection.close(.normalClosure)
+```


### PR DESCRIPTION
### Refactor / Chore
Phase 2 design output — 14 scoped spec documents covering the full library design.

**Specs:**
- `overview.md` — project scope, modules, platforms
- `public-api.md` — `@Client`, `@API`, parameter rules, return types
- `request-response.md` — Request builder, Response
- `middleware.md` — protocol, composition, built-ins, helpers
- `request-metadata.md` — extensible storage, built-in keys
- `network-client.md` — configuration, send methods, internal flow
- `transport.md` — protocol, URLSession, TransportTask
- `errors.md` — NetworkError, Kind enum, pattern matching
- `macros.md` — implementation design, diagnostics, validation
- `sse.md` — parser, reconnection, SSEEventDecodable, `@SSEEvents`
- `websocket.md` — WebSocketConnection, lifecycle
- `encoding.md` — content types, encoders, QueryEncoder, MultipartFormData
- `feature-types.md` — RetryPolicy, CachePolicy, Transfer, pagination
- `package.md` — Package.swift structure

---

## Test Plan
- Documentation only, no code changes

---

## Checklist

- [x] `make build` passes
- [ ] New/changed public API has documentation
- [ ] Breaking changes are noted above