### PR TITLE
docs: add implementation plans and roadmap

### DIFF
--- a/docs/networking/plans/minimal-end-to-end.md
+++ b/docs/networking/plans/minimal-end-to-end.md
@@ -7,6 +7,67 @@ Milestone: Minimal End-to-End
 
 A developer can define a `@Client` struct with `@GET`/`@POST` endpoints, create a `NetworkClient`, and make type-safe HTTP requests with JSON encoding/decoding.
 
+## Implementation Layers
+
+AC1 is split into 4 architectural layers, each with its own ATDD test. Layers 2 and 3 can be worked in parallel after Layer 1.
+
+```
+Layer 1 (#32) ─────┬──── Layer 2 (#33) ──── #9-12, #19-25 (11 issues)
+                   │
+                   ├──── Layer 3 (#34) ──── #26-30 (5 issues)
+                   │
+                   └──── Layer 4 (#6) ───── #7-8, #13-18 (8 issues)
+                         (needs L2+L3)
+```
+
+### Layer 1 — Core Types (#32)
+Request, Response, HTTPMethod, HeaderKey, RequestMetadata, RequestMetadataKey, NetworkError, ResponseDecoding, RequestEncoding.
+ATDD: construct `Request.get("/users/123")` with all properties.
+
+### Layer 2 — NetworkClient + Transport (#33)
+Transport protocol, MockTransport, Request→URLRequest conversion, Response conversion, middleware chain (MiddlewareBuilder), NetworkClient.send()/data()/string().
+ATDD: `NetworkClient.send(request, as: User.self)` decodes via MockTransport.
+Blocked by: Layer 1.
+
+### Layer 3 — Macros (#34)
+MarkerMacro, @GET/@POST/@DELETE declarations, PathValidation, ClosureTypeParsing, ClientMacro, NetworkingMacrosPlugin.
+ATDD: `assertMacroExpansion` generates correct `init(network:)`.
+Blocked by: Layer 1. Parallel with Layer 2.
+
+### Layer 4 — Integration (#6)
+Full pipeline test: @Client with @GET("/{id}"), call endpoint, get decoded User.
+ATDD: the original AC1 acceptance test.
+Blocked by: Layers 2 + 3.
+
+## Blocking Structure
+
+| Blocked by Layer 2 | Blocked by Layer 3 | Blocked by Layer 4 |
+|---|---|---|
+| #9 AC4 (error status) | #26 AC21 (macro gen) | #7 AC2 (GET no params) |
+| #10 AC5 (transport fail) | #27 AC22 (default path) | #8 AC3 (multi path params) |
+| #11 AC6 (malformed body) | #28 AC23 (path mismatch) | #13 AC8 (POST happy path) |
+| #12 AC7 (empty body) | #29 AC24 (multi methods) | #14 AC9 (encoding fail) |
+| #19 AC14 (no middleware) | #30 AC25 (non-struct) | #15 AC10 (path + body) |
+| #20 AC15 (single middleware) | | #16 AC11 (query + body) |
+| #21 AC16 (middleware order) | | #17 AC12 (query params) |
+| #22 AC17 (short-circuit) | | #18 AC13 (optional query) |
+| #23 AC18 (Void return) | | |
+| #24 AC19 (Data return) | | |
+| #25 AC20 (String return) | | |
+
+## Review Decisions
+
+### Cherry-picks (added to scope)
+- **CustomStringConvertible** on Request, Response, NetworkError — debugging ergonomics (Layer 1)
+- **Custom `~=` operator** for `NetworkError.Kind` range matching — `case .invalidStatus(400...499)` (Layer 1)
+- **Hybrid URL validation** — strip trailing slash, require scheme, prepend missing `/` (Layer 2)
+
+### Architectural Decisions
+1. **Encoding error wrapping:** Macro-generated code catches `EncodingError` and wraps in `NetworkError(.encodingFailed)` via do/catch
+2. **URL construction failure:** precondition (programming error, validated at init)
+3. **UTF-8 decode failure:** `NetworkError(.decodingFailed)` for consistency
+4. **Special return type errors:** Void/Data/String still throw `.invalidStatus` on non-2xx
+
 ## Package.swift
 
 Targets and dependencies are added when needed — not all at once upfront.


### PR DESCRIPTION
## Summary
- Add Minimal End-to-End implementation plan with layer structure, blocking relationships, and review decisions
- Add roadmap mapping all 10 milestones to relevant specs
- Update middleware spec with MiddlewareBuilder details

## Review Decisions Captured
- AC1 split into 4 layers (core types → NetworkClient → macros → integration)
- 3 cherry-picks: CustomStringConvertible, NetworkError.Kind ~= operator, URL validation
- 4 architectural decisions: encoding wrapping, URL precondition, UTF-8 handling, return type errors

## Test plan
- Documentation only, no code changes