### PR TITLE
[Package] Set up SPM package structure and tooling config

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,9 +4,6 @@ included:
   - Sources
   - Tests
 
-excluded:
-  - Resource
-
 disabled_rules:
   - identifier_name
   - line_length
@@ -76,7 +73,7 @@ opt_in_rules:
   - private_action
   - private_outlet
   - redundant_nil_coalescing
-  - redundant_self_in_closure
+  - redundant_self
   - redundant_type_annotation
   - required_enum_case
   - return_value_from_void_function

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f33022d0de772c3631b024c35c940995ad4ce0247d27d192e4c44c779bf29514",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,46 @@
 // swift-tools-version: 6.0
 
+import CompilerPluginSupport
 import PackageDescription
 
 let package = Package(
-    name: "swift-networking"
+    name: "swift-networking",
+    platforms: [
+        .iOS(.v16),
+        .macOS(.v13),
+        .watchOS(.v9),
+        .tvOS(.v16),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(name: "Networking", targets: ["Networking"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"605.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Networking",
+            dependencies: ["NetworkingMacros"]
+        ),
+        .macro(
+            name: "NetworkingMacros",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            ]
+        ),
+        .testTarget(
+            name: "NetworkingTests",
+            dependencies: ["Networking"]
+        ),
+        .testTarget(
+            name: "NetworkingMacroTests",
+            dependencies: [
+                "NetworkingMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
+    ]
 )

--- a/Sources/Networking/Networking.swift
+++ b/Sources/Networking/Networking.swift
@@ -1,0 +1,1 @@
+// TODO: Add Networking module public API

--- a/Sources/NetworkingMacros/NetworkingMacrosPlugin.swift
+++ b/Sources/NetworkingMacros/NetworkingMacrosPlugin.swift
@@ -1,0 +1,9 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct NetworkingMacrosPlugin: CompilerPlugin {
+    var providingMacros: [any Macro.Type] {
+        []
+    }
+}

--- a/Tests/NetworkingMacroTests/NetworkingMacroTests.swift
+++ b/Tests/NetworkingMacroTests/NetworkingMacroTests.swift
@@ -1,0 +1,1 @@
+// TODO: Add macro expansion tests

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -1,0 +1,1 @@
+// TODO: Add Networking integration tests


### PR DESCRIPTION
## Summary
- Add 4 SPM targets (`Networking`, `NetworkingMacros`, `NetworkingTests`, `NetworkingMacroTests`) with swift-syntax dependency and platform config
- Import `CompilerPluginSupport` to fix `.macro` target recognition
- Fix SwiftLint config: remove stale excluded path, rename deprecated rule

## Test plan
- [x] `swift build` succeeds with all 4 targets
- [x] `swift test` succeeds (0 tests, 0 failures)
- [x] `make lint` passes (0 violations)
- [x] `make format-check` passes

Closes #37