### PR TITLE
[Response] Response (#42)

### DIFF
--- a/Sources/Networking/Response/Response.swift
+++ b/Sources/Networking/Response/Response.swift
@@ -11,6 +11,10 @@ public struct Response: Sendable, Equatable {
         self.body = body
     }
 
+    public subscript(header key: HeaderKey) -> String? {
+        headers[key]
+    }
+
     public var isSuccess: Bool { (200...299).contains(statusCode) }
     public var isRedirect: Bool { (300...399).contains(statusCode) }
     public var isClientError: Bool { (400...499).contains(statusCode) }

--- a/Sources/Networking/Response/Response.swift
+++ b/Sources/Networking/Response/Response.swift
@@ -10,4 +10,9 @@ public struct Response: Sendable, Equatable {
         self.headers = headers
         self.body = body
     }
+
+    public var isSuccess: Bool { (200...299).contains(statusCode) }
+    public var isRedirect: Bool { (300...399).contains(statusCode) }
+    public var isClientError: Bool { (400...499).contains(statusCode) }
+    public var isServerError: Bool { (500...599).contains(statusCode) }
 }

--- a/Sources/Networking/Response/Response.swift
+++ b/Sources/Networking/Response/Response.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct Response: Sendable, Equatable {
+    public let statusCode: Int
+    public let headers: [HeaderKey: String]
+    public var body: Data
+
+    public init(statusCode: Int, headers: [HeaderKey: String], body: Data) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+    }
+}

--- a/Tests/NetworkingTests/Response/ResponseTests.swift
+++ b/Tests/NetworkingTests/Response/ResponseTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+
+@testable import Networking
+
+@Suite("Response")
+struct ResponseTests {
+    @Suite("Construction")
+    struct Construction {
+        @Test
+        func initSetsAllProperties() {
+            let headers: [HeaderKey: String] = [
+                .contentType: "application/json",
+                .authorization: "Bearer token",
+            ]
+            let body = Data("hello".utf8)
+
+            let response = Response(
+                statusCode: 200,
+                headers: headers,
+                body: body
+            )
+
+            #expect(response.statusCode == 200)
+            #expect(response.headers == headers)
+            #expect(response.body == body)
+        }
+    }
+    @Suite("Body")
+    struct Body {
+        @Test
+        func bodyIsNonOptionalData() {
+            let response = Response(
+                statusCode: 204,
+                headers: [:],
+                body: Data()
+            )
+
+            let body: Data = response.body
+            #expect(body.isEmpty)
+        }
+
+        @Test
+        func bodyIsMutable() {
+            var response = Response(
+                statusCode: 200,
+                headers: [:],
+                body: Data()
+            )
+
+            response.body = Data("transformed".utf8)
+            #expect(response.body == Data("transformed".utf8))
+        }
+    }
+    @Suite("Status Categories")
+    struct StatusCategories {
+        @Test(arguments: [200, 201, 250, 299])
+        func isSuccess(statusCode: Int) {
+            #expect(Response(statusCode: statusCode, headers: [:], body: Data()).isSuccess)
+        }
+
+        @Test(arguments: [300, 301, 350, 399])
+        func isRedirect(statusCode: Int) {
+            #expect(Response(statusCode: statusCode, headers: [:], body: Data()).isRedirect)
+        }
+
+        @Test(arguments: [400, 404, 450, 499])
+        func isClientError(statusCode: Int) {
+            #expect(Response(statusCode: statusCode, headers: [:], body: Data()).isClientError)
+        }
+
+        @Test(arguments: [500, 503, 550, 599])
+        func isServerError(statusCode: Int) {
+            #expect(Response(statusCode: statusCode, headers: [:], body: Data()).isServerError)
+        }
+
+        @Test(arguments: [0, 199, 600])
+        func outsideKnownRangesMatchNothing(statusCode: Int) {
+            let response = Response(statusCode: statusCode, headers: [:], body: Data())
+            #expect(
+                !response.isSuccess && !response.isRedirect && !response.isClientError
+                    && !response.isServerError)
+        }
+
+        @Test(arguments: [200, 300, 400, 500])
+        func categoriesAreMutuallyExclusive(statusCode: Int) {
+            let response = Response(statusCode: statusCode, headers: [:], body: Data())
+            let count = [
+                response.isSuccess, response.isRedirect, response.isClientError,
+                response.isServerError,
+            ]
+            .filter { $0 }.count
+            #expect(count == 1)
+        }
+    }
+    @Suite("Header Subscript")
+    struct HeaderSubscript {
+        @Test
+        func accessExistingHeader() {
+            let response = Response(
+                statusCode: 200,
+                headers: [.contentType: "application/json"],
+                body: Data()
+            )
+
+            #expect(response[header: .contentType] == "application/json")
+        }
+
+        @Test
+        func accessMissingHeaderReturnsNil() {
+            let response = Response(
+                statusCode: 200,
+                headers: [:],
+                body: Data()
+            )
+
+            #expect(response[header: .contentType] == nil)
+        }
+    }
+    @Suite("Equatable")
+    struct EquatableConformance {
+        @Test
+        func equalResponses() {
+            let a = Response(
+                statusCode: 200, headers: [.contentType: "text/plain"], body: Data("ok".utf8))
+            let b = Response(
+                statusCode: 200, headers: [.contentType: "text/plain"], body: Data("ok".utf8))
+            #expect(a == b)
+        }
+
+        @Test
+        func differentStatusCodeNotEqual() {
+            let a = Response(statusCode: 200, headers: [:], body: Data())
+            let b = Response(statusCode: 201, headers: [:], body: Data())
+            #expect(a != b)
+        }
+
+        @Test
+        func differentHeadersNotEqual() {
+            let a = Response(statusCode: 200, headers: [.contentType: "text/plain"], body: Data())
+            let b = Response(
+                statusCode: 200, headers: [.contentType: "application/json"], body: Data())
+            #expect(a != b)
+        }
+
+        @Test
+        func differentBodyNotEqual() {
+            let a = Response(statusCode: 200, headers: [:], body: Data("a".utf8))
+            let b = Response(statusCode: 200, headers: [:], body: Data("b".utf8))
+            #expect(a != b)
+        }
+    }
+}

--- a/Tests/NetworkingTests/Response/ResponseTests.swift
+++ b/Tests/NetworkingTests/Response/ResponseTests.swift
@@ -107,6 +107,17 @@ struct ResponseTests {
         }
 
         @Test
+        func accessHeaderWithDifferentCasing() {
+            let response = Response(
+                statusCode: 200,
+                headers: [HeaderKey("Content-Type"): "application/json"],
+                body: Data()
+            )
+
+            #expect(response[header: HeaderKey("content-type")] == "application/json")
+        }
+
+        @Test
         func accessMissingHeaderReturnsNil() {
             let response = Response(
                 statusCode: 200,


### PR DESCRIPTION
Closes #42

## Description

### Feature

Adds the `Response` struct to the Networking module — the counterpart to `Request` for representing HTTP responses.

**Acceptance Criteria:**
- [x] Status category computed properties (`isSuccess`, `isRedirect`, `isClientError`, `isServerError`)
- [x] Status ranges: 200-299, 300-399, 400-499, 500-599
- [x] Status codes outside known ranges return false for all helpers
- [x] Typed header access via `response[header: .contentType]` returning `String?`
- [x] Body is non-optional `Data` (empty, never nil)
- [x] Construction via `Response(statusCode:headers:body:)` with immutable headers and mutable body
- [x] Response header subscript is get-only (no setter)

**User Flow:**

Transport layer creates a `Response` from raw HTTP data. Middleware and callers inspect status via helpers (`response.isSuccess`), read headers via typed subscript (`response[header: .contentType]`), and transform body as needed (`response.body = decoded`).

---

## Test Plan

`swift test --filter ResponseTests` — 16 tests across 6 suites:
- **Construction** — init sets all properties
- **Body** — non-optional Data, mutable
- **Status Categories** — parameterized tests for each range, boundary codes, mutual exclusivity, outside-range codes
- **Header Subscript** — existing header, missing header, case-insensitive access
- **Equatable** — equal/different statusCode, headers, body

---

## Additional Notes

- Headers stored as `[HeaderKey: String]` instead of `[String: String]` (deviation from original issue spec) — enforces case-insensitive lookup at the storage level via `HeaderKey`'s `Hashable` conformance.

---

## Checklist

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [ ] New/changed public API has documentation
- [x] Breaking changes are noted above