### PR TITLE
[Request] Request (#43)

### DIFF
--- a/Sources/Networking/Request/Request.swift
+++ b/Sources/Networking/Request/Request.swift
@@ -51,19 +51,27 @@ extension Request {
 
 extension Request {
     public func header(_ key: HeaderKey, _ value: String) -> Request {
-        self
+        var copy = self
+        copy.headers[key] = value
+        return copy
     }
 
     public func query(_ name: String, _ value: String) -> Request {
-        self
+        var copy = self
+        copy.query.append(URLQueryItem(name: name, value: value))
+        return copy
     }
 
     public func body(_ body: Data) -> Request {
-        self
+        var copy = self
+        copy.body = body
+        return copy
     }
 
     public func metadata<K: RequestMetadataKey>(_ key: K.Type, _ value: K.Value) -> Request {
-        self
+        var copy = self
+        copy.metadata[key] = value
+        return copy
     }
 }
 

--- a/Sources/Networking/Request/Request.swift
+++ b/Sources/Networking/Request/Request.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public struct Request: Sendable {
+    public let method: HTTPMethod
+    public let path: String
+    public var headers: [HeaderKey: String]
+    public var query: [URLQueryItem]
+    public var body: Data?
+    public var metadata: RequestMetadata
+
+    public init(
+        method: HTTPMethod,
+        path: String,
+        headers: [HeaderKey: String] = [:],
+        query: [URLQueryItem] = [],
+        body: Data? = nil,
+        metadata: RequestMetadata = RequestMetadata()
+    ) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.query = query
+        self.body = body
+        self.metadata = metadata
+    }
+}
+
+extension Request {
+    public static func get(_ path: String) -> Request {
+        Request(method: .get, path: path)
+    }
+
+    public static func post(_ path: String) -> Request {
+        Request(method: .post, path: path)
+    }
+
+    public static func put(_ path: String) -> Request {
+        Request(method: .put, path: path)
+    }
+
+    public static func delete(_ path: String) -> Request {
+        Request(method: .delete, path: path)
+    }
+
+    public static func patch(_ path: String) -> Request {
+        Request(method: .patch, path: path)
+    }
+}
+
+// MARK: - Builders
+
+extension Request {
+    public func header(_ key: HeaderKey, _ value: String) -> Request {
+        self
+    }
+
+    public func query(_ name: String, _ value: String) -> Request {
+        self
+    }
+
+    public func body(_ body: Data) -> Request {
+        self
+    }
+
+    public func metadata<K: RequestMetadataKey>(_ key: K.Type, _ value: K.Value) -> Request {
+        self
+    }
+}
+
+// MARK: - Header Subscript
+
+extension Request {
+    public subscript(header key: HeaderKey) -> String? {
+        get { nil }
+        set {}
+    }
+}

--- a/Sources/Networking/Request/Request.swift
+++ b/Sources/Networking/Request/Request.swift
@@ -79,7 +79,7 @@ extension Request {
 
 extension Request {
     public subscript(header key: HeaderKey) -> String? {
-        get { nil }
-        set {}
+        get { headers[key] }
+        set { headers[key] = newValue }
     }
 }

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -237,6 +237,40 @@ struct RequestTests {
         }
     }
 
+    @Suite("Three Write Paths")
+    struct ThreeWritePaths {
+        @Test
+        func builderSubscriptAndRawDictAllSetHeaders() {
+            let viaBuilder = Request.get("/a")
+                .header(.authorization, "token")
+
+            var viaSubscript = Request.get("/a")
+            viaSubscript[header: .authorization] = "token"
+
+            var viaRawDict = Request.get("/a")
+            viaRawDict.headers[.authorization] = "token"
+
+            #expect(viaBuilder.headers[.authorization] == "token")
+            #expect(viaSubscript.headers[.authorization] == "token")
+            #expect(viaRawDict.headers[.authorization] == "token")
+        }
+    }
+
+    @Suite("Path Validation")
+    struct PathValidation {
+        @Test
+        func emptyPathAccepted() {
+            let request = Request.get("")
+            #expect(request.path == "")
+        }
+
+        @Test
+        func nonSlashPrefixedPathAccepted() {
+            let request = Request.get("users")
+            #expect(request.path == "users")
+        }
+    }
+
     @Suite("Acceptance")
     struct Acceptance {
         @Test

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -202,6 +202,41 @@ struct RequestTests {
         }
     }
 
+    @Suite("Header Subscript")
+    struct HeaderSubscript {
+        @Test
+        func getReturnsValueWhenSet() {
+            let request = Request.get("/a")
+                .header(.authorization, "Bearer token")
+
+            #expect(request[header: .authorization] == "Bearer token")
+        }
+
+        @Test
+        func getReturnsNilWhenMissing() {
+            let request = Request.get("/a")
+
+            #expect(request[header: .authorization] == nil)
+        }
+
+        @Test
+        func setUpdatesHeaderInPlace() {
+            var request = Request.get("/a")
+            request[header: .authorization] = "Bearer token"
+
+            #expect(request.headers[.authorization] == "Bearer token")
+        }
+
+        @Test
+        func setOverwritesExistingValue() {
+            var request = Request.get("/a")
+                .header(.authorization, "first")
+            request[header: .authorization] = "second"
+
+            #expect(request[header: .authorization] == "second")
+        }
+    }
+
     @Suite("Acceptance")
     struct Acceptance {
         @Test

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import Networking
+
+// MARK: - Test Keys
+
+private enum TagKey: RequestMetadataKey {
+    static let defaultValue: String = ""
+}
+
+// MARK: - Tests
+
+@Suite("Request")
+struct RequestTests {
+    @Suite("Acceptance")
+    struct Acceptance {
+        @Test
+        func minimalGetRequest() {
+            let request = Request.get("/users")
+
+            #expect(request.method == .get)
+            #expect(request.path == "/users")
+            #expect(request.headers.isEmpty)
+            #expect(request.query.isEmpty)
+            #expect(request.body == nil)
+            #expect(request.metadata[TagKey.self].isEmpty)
+        }
+
+        @Test
+        func builderChainingAppliesAllModifications() {
+            let body = Data("{}".utf8)
+            let request = Request.post("/items")
+                .header(.authorization, "Bearer token")
+                .query("page", "1")
+                .body(body)
+                .metadata(TagKey.self, "tagged")
+
+            #expect(request.method == .post)
+            #expect(request.path == "/items")
+            #expect(request.headers[.authorization] == "Bearer token")
+            #expect(request.query.first?.name == "page")
+            #expect(request.query.first?.value == "1")
+            #expect(request.body == body)
+            #expect(request.metadata[TagKey.self] == "tagged")
+        }
+
+        @Test
+        func builderReturnsNewCopyOriginalUnchanged() {
+            let original = Request.get("/users")
+            let modified = original.header(.authorization, "Bearer token")
+
+            #expect(original.headers.isEmpty)
+            #expect(modified.headers[.authorization] == "Bearer token")
+        }
+
+        @Test
+        func headerSubscriptGetAndSet() {
+            var request = Request.get("/users")
+            #expect(request[header: .authorization] == nil)
+
+            request[header: .authorization] = "Bearer token"
+            #expect(request[header: .authorization] == "Bearer token")
+        }
+
+        @Test
+        func threeHeaderWritePaths() {
+            let viaBuilder = Request.get("/a")
+                .header(.authorization, "token")
+
+            var viaSubscript = Request.get("/a")
+            viaSubscript[header: .authorization] = "token"
+
+            var viaRawDict = Request.get("/a")
+            viaRawDict.headers[.authorization] = "token"
+
+            #expect(viaBuilder[header: .authorization] == "token")
+            #expect(viaSubscript[header: .authorization] == "token")
+            #expect(viaRawDict[header: .authorization] == "token")
+        }
+
+        @Test
+        func pathAcceptsAnyString() {
+            let empty = Request.get("")
+            let noSlash = Request.get("users")
+
+            #expect(empty.path == "")
+            #expect(noSlash.path == "users")
+        }
+    }
+}

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -96,6 +96,85 @@ struct RequestTests {
         }
     }
 
+    @Suite("Builders")
+    struct Builders {
+        @Suite("Header")
+        struct Header {
+            @Test
+            func addsHeader() {
+                let request = Request.get("/a")
+                    .header(.authorization, "Bearer token")
+
+                #expect(request.headers[.authorization] == "Bearer token")
+            }
+
+            @Test
+            func originalUnchanged() {
+                let original = Request.get("/a")
+                let modified = original.header(.authorization, "Bearer token")
+
+                #expect(original.headers.isEmpty)
+                #expect(modified.headers[.authorization] == "Bearer token")
+            }
+
+            @Test
+            func sameKeyOverwrites() {
+                let request = Request.get("/a")
+                    .header(.authorization, "first")
+                    .header(.authorization, "second")
+
+                #expect(request.headers[.authorization] == "second")
+            }
+        }
+
+        @Suite("Query")
+        struct Query {
+            @Test
+            func appendsQueryItem() {
+                let request = Request.get("/a")
+                    .query("page", "1")
+
+                #expect(request.query.count == 1)
+                #expect(request.query.first?.name == "page")
+                #expect(request.query.first?.value == "1")
+            }
+
+            @Test
+            func preservesExistingItems() {
+                let request = Request.get("/a")
+                    .query("page", "1")
+                    .query("limit", "10")
+
+                #expect(request.query.count == 2)
+                #expect(request.query[0].name == "page")
+                #expect(request.query[1].name == "limit")
+            }
+        }
+
+        @Suite("Body")
+        struct Body {
+            @Test
+            func setsBody() {
+                let data = Data("{}".utf8)
+                let request = Request.get("/a")
+                    .body(data)
+
+                #expect(request.body == data)
+            }
+        }
+
+        @Suite("Metadata")
+        struct Metadata {
+            @Test
+            func setsMetadataKey() {
+                let request = Request.get("/a")
+                    .metadata(TagKey.self, "tagged")
+
+                #expect(request.metadata[TagKey.self] == "tagged")
+            }
+        }
+    }
+
     @Suite("Acceptance")
     struct Acceptance {
         @Test

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -13,6 +13,89 @@ private enum TagKey: RequestMetadataKey {
 
 @Suite("Request")
 struct RequestTests {
+    @Suite("Static Factories")
+    struct StaticFactories {
+        @Test
+        func getFactory() {
+            let request = Request.get("/users")
+
+            #expect(request.method == .get)
+            #expect(request.path == "/users")
+        }
+
+        @Test
+        func postFactory() {
+            let request = Request.post("/items")
+
+            #expect(request.method == .post)
+            #expect(request.path == "/items")
+        }
+
+        @Test
+        func putFactory() {
+            let request = Request.put("/items/1")
+
+            #expect(request.method == .put)
+            #expect(request.path == "/items/1")
+        }
+
+        @Test
+        func deleteFactory() {
+            let request = Request.delete("/items/1")
+
+            #expect(request.method == .delete)
+            #expect(request.path == "/items/1")
+        }
+
+        @Test
+        func patchFactory() {
+            let request = Request.patch("/items/1")
+
+            #expect(request.method == .patch)
+            #expect(request.path == "/items/1")
+        }
+
+        @Test
+        func factoryDefaultsAreEmpty() {
+            let request = Request.get("/users")
+
+            #expect(request.headers.isEmpty)
+            #expect(request.query.isEmpty)
+            #expect(request.body == nil)
+        }
+    }
+
+    @Suite("Memberwise Init")
+    struct MemberwiseInit {
+        @Test
+        func fullInit() {
+            let body = Data("{}".utf8)
+            let request = Request(
+                method: .post,
+                path: "/items",
+                headers: [.contentType: "application/json"],
+                query: [URLQueryItem(name: "v", value: "2")],
+                body: body,
+                metadata: RequestMetadata()
+            )
+
+            #expect(request.method == .post)
+            #expect(request.path == "/items")
+            #expect(request.headers[.contentType] == "application/json")
+            #expect(request.query.count == 1)
+            #expect(request.body == body)
+        }
+
+        @Test
+        func defaultsAfterPath() {
+            let request = Request(method: .get, path: "/users")
+
+            #expect(request.headers.isEmpty)
+            #expect(request.query.isEmpty)
+            #expect(request.body == nil)
+        }
+    }
+
     @Suite("Acceptance")
     struct Acceptance {
         @Test

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -175,6 +175,33 @@ struct RequestTests {
         }
     }
 
+    @Suite("Builder Chaining")
+    struct BuilderChaining {
+        @Test
+        func allBuildersInDifferentOrders() {
+            let body = Data("{}".utf8)
+
+            let orderA = Request.post("/items")
+                .header(.contentType, "application/json")
+                .query("v", "2")
+                .body(body)
+                .metadata(TagKey.self, "a")
+
+            let orderB = Request.post("/items")
+                .body(body)
+                .metadata(TagKey.self, "a")
+                .header(.contentType, "application/json")
+                .query("v", "2")
+
+            #expect(orderA.method == orderB.method)
+            #expect(orderA.path == orderB.path)
+            #expect(orderA.headers == orderB.headers)
+            #expect(orderA.query == orderB.query)
+            #expect(orderA.body == orderB.body)
+            #expect(orderA.metadata[TagKey.self] == orderB.metadata[TagKey.self])
+        }
+    }
+
     @Suite("Acceptance")
     struct Acceptance {
         @Test

--- a/Tests/NetworkingTests/Request/RequestTests.swift
+++ b/Tests/NetworkingTests/Request/RequestTests.swift
@@ -149,6 +149,17 @@ struct RequestTests {
                 #expect(request.query[0].name == "page")
                 #expect(request.query[1].name == "limit")
             }
+
+            @Test
+            func duplicateNamesAllowed() {
+                let request = Request.get("/a")
+                    .query("color", "red")
+                    .query("color", "blue")
+
+                #expect(request.query.count == 2)
+                #expect(request.query[0].value == "red")
+                #expect(request.query[1].value == "blue")
+            }
         }
 
         @Suite("Body")
@@ -234,6 +245,16 @@ struct RequestTests {
             request[header: .authorization] = "second"
 
             #expect(request[header: .authorization] == "second")
+        }
+
+        @Test
+        func setToNilRemovesHeader() {
+            var request = Request.get("/a")
+                .header(.authorization, "Bearer token")
+            request[header: .authorization] = nil
+
+            #expect(request[header: .authorization] == nil)
+            #expect(request.headers.isEmpty)
         }
     }
 


### PR DESCRIPTION
Closes #43

## Description

### Feature

Adds the `Request` struct — the core request type for the Networking library. Implements all 10 acceptance criteria from #43.

**Acceptance Criteria:**
- [x] S1-AC1: Minimal request via static factory (`.get()`, `.post()`, `.put()`, `.delete()`, `.patch()`)
- [x] S1-AC3: Full memberwise init with defaults after `path`
- [x] S1-AC4: Header builder with overwrite semantics (last write wins, copy on write)
- [x] S1-AC5: Query builder (appends, preserves existing)
- [x] S1-AC6: Body builder
- [x] S1-AC7: Metadata builder
- [x] S1-AC8: Builder chaining is order-independent
- [x] S1-AC10: Path accepts any string (no validation at Core Types layer)
- [x] S4-AC4: Header subscript get/set on Request
- [x] S4-AC5: Three header write paths (builder, subscript, raw dict)

**Design Decision:** `headers` uses `[HeaderKey: String]` (not `[String: String]`) for consistency with `Response`. The raw dict write path uses `request.headers[.authorization]` instead of string keys.

---

## Test Plan

31 unit tests across 13 suites:
- Static Factories (6 tests)
- Memberwise Init (2 tests)
- Builders: Header/Query/Body/Metadata (8 tests)
- Builder Chaining (1 test)
- Header Subscript (5 tests)
- Three Write Paths (1 test)
- Path Validation (2 tests)
- Acceptance (6 end-to-end tests)

```bash
swift test --filter RequestTests
```

---

## Checklist

- [x] `swift build` passes
- [x] `swift test` passes (74/74 total)
- [x] New public API matches spec
- [x] `make lint` passes