### PR TITLE
[Error] NetworkError (#44)

### DIFF
--- a/Sources/Networking/Error/NetworkError.swift
+++ b/Sources/Networking/Error/NetworkError.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public struct NetworkError: Error, Sendable {
+    public let kind: Kind
+    public let request: Request
+    public let response: Response?
+
+    public init(kind: Kind, request: Request, response: Response?) {
+        self.kind = kind
+        self.request = request
+        self.response = response
+    }
+}
+
+extension NetworkError {
+    public enum Kind: Sendable {
+        case invalidStatus(Int)
+        case decodingFailed(any Error & Sendable)
+        case transportFailed(any Error & Sendable)
+        case encodingFailed(any Error & Sendable)
+    }
+}
+
+// MARK: - Pattern Matching
+
+extension NetworkError {
+    public static func ~= (code: Int, error: NetworkError) -> Bool {
+        guard case .invalidStatus(let status) = error.kind else { return false }
+        return status == code
+    }
+
+    public static func ~= <R: RangeExpression<Int>>(range: R, error: NetworkError) -> Bool {
+        guard case .invalidStatus(let status) = error.kind else { return false }
+        return range.contains(status)
+    }
+}
+
+// MARK: - Convenience Properties
+
+extension NetworkError {
+    public var statusCode: Int? { response?.statusCode }
+    public var body: Data? { response?.body }
+    public var headers: [HeaderKey: String]? { response?.headers }
+    public var isClientError: Bool { response?.isClientError ?? false }
+    public var isServerError: Bool { response?.isServerError ?? false }
+}
+

--- a/Sources/Networking/Error/NetworkError.swift
+++ b/Sources/Networking/Error/NetworkError.swift
@@ -38,10 +38,14 @@ extension NetworkError {
 // MARK: - Convenience Properties
 
 extension NetworkError {
-    public var statusCode: Int? { response?.statusCode }
+    public var statusCode: Int? {
+        guard case .invalidStatus(let code) = kind else { return nil }
+        return code
+    }
+
     public var body: Data? { response?.body }
     public var headers: [HeaderKey: String]? { response?.headers }
-    public var isClientError: Bool { response?.isClientError ?? false }
-    public var isServerError: Bool { response?.isServerError ?? false }
+    public var isClientError: Bool { statusCode.map { (400...499).contains($0) } ?? false }
+    public var isServerError: Bool { statusCode.map { (500...599).contains($0) } ?? false }
 }
 

--- a/Tests/NetworkingTests/Error/NetworkErrorTests.swift
+++ b/Tests/NetworkingTests/Error/NetworkErrorTests.swift
@@ -6,6 +6,24 @@ import Testing
 @Suite("NetworkError")
 struct NetworkErrorTests {
 
+    // MARK: - Factories
+
+    static func httpError(statusCode: Int) -> NetworkError {
+        NetworkError(
+            kind: .invalidStatus(statusCode),
+            request: .get("/"),
+            response: Response(statusCode: statusCode, headers: [:], body: Data())
+        )
+    }
+
+    static func transportError(_ error: some Error & Sendable) -> NetworkError {
+        NetworkError(
+            kind: .transportFailed(error),
+            request: .get("/"),
+            response: nil
+        )
+    }
+
     @Suite("Error Structure")
     struct ErrorStructure {
         @Test("carries kind, request, and response")
@@ -128,7 +146,7 @@ struct NetworkErrorTests {
     struct DirectPatternMatching {
         @Test("exact Int match on NetworkError")
         func exactIntMatch() {
-            let error = NetworkError.http(statusCode: 404)
+            let error = NetworkErrorTests.httpError(statusCode: 404)
             switch error {
             case 404:
                 break // passes
@@ -139,7 +157,7 @@ struct NetworkErrorTests {
 
         @Test("range match on NetworkError for 5xx")
         func rangeMatch() {
-            let error = NetworkError.http(statusCode: 503)
+            let error = NetworkErrorTests.httpError(statusCode: 503)
             switch error {
             case 500...:
                 break // passes
@@ -150,7 +168,7 @@ struct NetworkErrorTests {
 
         @Test("non-invalidStatus kind does not match any status code")
         func nonStatusKindNoMatch() {
-            let error = NetworkError.transportError(URLError(.timedOut))
+            let error = NetworkErrorTests.transportError(URLError(.timedOut))
             switch error {
             case 500:
                 Issue.record("transportFailed should not match status codes")
@@ -162,15 +180,14 @@ struct NetworkErrorTests {
 
     @Suite("Convenience Properties with Response")
     struct ConvenienceWithResponse {
-        static let response = Response(
-            statusCode: 404,
-            headers: [.contentType: "application/json"],
-            body: Data("not found".utf8)
-        )
-        static let error = NetworkError(
+        let error = NetworkError(
             kind: .invalidStatus(404),
             request: .get("/test"),
-            response: response
+            response: Response(
+                statusCode: 404,
+                headers: [.contentType: "application/json"],
+                body: Data("not found".utf8)
+            )
         )
 
         @Test("statusCode returns response status code")
@@ -212,7 +229,7 @@ struct NetworkErrorTests {
 
     @Suite("Convenience Properties without Response")
     struct ConvenienceWithoutResponse {
-        static let error = NetworkError(
+        let error = NetworkError(
             kind: .transportFailed(URLError(.notConnectedToInternet)),
             request: .get("/test"),
             response: nil
@@ -248,7 +265,7 @@ struct NetworkErrorTests {
     struct FactoryMethods {
         @Test("http(statusCode:) creates invalidStatus error")
         func httpFactory() {
-            let error = NetworkError.http(statusCode: 500)
+            let error = NetworkErrorTests.httpError(statusCode: 500)
             if case .invalidStatus(500) = error.kind {
                 // passes
             } else {
@@ -259,7 +276,7 @@ struct NetworkErrorTests {
         @Test("transportError creates transportFailed error")
         func transportFactory() {
             let underlying = URLError(.timedOut)
-            let error = NetworkError.transportError(underlying)
+            let error = NetworkErrorTests.transportError(underlying)
             if case .transportFailed = error.kind {
                 // passes
             } else {
@@ -269,7 +286,7 @@ struct NetworkErrorTests {
 
         @Test("factory errors carry stub request")
         func factoryCarriesStubRequest() {
-            let error = NetworkError.http(statusCode: 404)
+            let error = NetworkErrorTests.httpError(statusCode: 404)
             #expect(error.request.method == .get)
         }
     }
@@ -278,7 +295,7 @@ struct NetworkErrorTests {
     struct ErrorConformance {
         @Test("NetworkError conforms to Error and can be thrown")
         func canBeThrown() {
-            let error = NetworkError.http(statusCode: 500)
+            let error = NetworkErrorTests.httpError(statusCode: 500)
             #expect(throws: NetworkError.self) {
                 throw error
             }

--- a/Tests/NetworkingTests/Error/NetworkErrorTests.swift
+++ b/Tests/NetworkingTests/Error/NetworkErrorTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import Testing
+
+@testable import Networking
+
+@Suite("NetworkError")
+struct NetworkErrorTests {
+
+    @Suite("Error Structure")
+    struct ErrorStructure {
+        @Test("carries kind, request, and response")
+        func errorCarriesAllFields() {
+            let request = Request.get("/test")
+            let response = Response(statusCode: 500, headers: [:], body: Data())
+            let error = NetworkError(
+                kind: .invalidStatus(500),
+                request: request,
+                response: response
+            )
+
+            #expect(error.request.path == "/test")
+            #expect(error.response?.statusCode == 500)
+        }
+
+        @Test("response is nil for transport failures")
+        func responseNilForTransportFailure() {
+            let request = Request.get("/test")
+            let underlying = URLError(.notConnectedToInternet)
+            let error = NetworkError(
+                kind: .transportFailed(underlying),
+                request: request,
+                response: nil
+            )
+
+            #expect(error.response == nil)
+        }
+
+        @Test("response is nil for encoding failures")
+        func responseNilForEncodingFailure() {
+            let request = Request.post("/test")
+            let underlying = URLError(.cannotDecodeContentData)
+            let error = NetworkError(
+                kind: .encodingFailed(underlying),
+                request: request,
+                response: nil
+            )
+
+            #expect(error.response == nil)
+        }
+    }
+
+    @Suite("Kind Enum Cases")
+    struct KindEnumCases {
+        @Test("invalidStatus carries status code")
+        func invalidStatus() {
+            let kind = NetworkError.Kind.invalidStatus(404)
+            if case .invalidStatus(let code) = kind {
+                #expect(code == 404)
+            } else {
+                Issue.record("Expected .invalidStatus")
+            }
+        }
+
+        @Test("decodingFailed carries underlying error")
+        func decodingFailed() {
+            let underlying = DecodingError.dataCorrupted(
+                .init(codingPath: [], debugDescription: "test")
+            )
+            let kind = NetworkError.Kind.decodingFailed(underlying)
+            if case .decodingFailed = kind {
+                // passes
+            } else {
+                Issue.record("Expected .decodingFailed")
+            }
+        }
+
+        @Test("transportFailed carries underlying error")
+        func transportFailed() {
+            let underlying = URLError(.timedOut)
+            let kind = NetworkError.Kind.transportFailed(underlying)
+            if case .transportFailed = kind {
+                // passes
+            } else {
+                Issue.record("Expected .transportFailed")
+            }
+        }
+
+        @Test("encodingFailed carries underlying error")
+        func encodingFailed() {
+            let underlying = EncodingError.invalidValue(
+                "", .init(codingPath: [], debugDescription: "test")
+            )
+            let kind = NetworkError.Kind.encodingFailed(underlying)
+            if case .encodingFailed = kind {
+                // passes
+            } else {
+                Issue.record("Expected .encodingFailed")
+            }
+        }
+    }
+
+    @Suite("Pattern Matching on Kind")
+    struct KindPatternMatching {
+        @Test("exact status code match on Kind")
+        func exactMatch() {
+            let kind = NetworkError.Kind.invalidStatus(404)
+            switch kind {
+            case .invalidStatus(404):
+                break // passes
+            default:
+                Issue.record("Expected .invalidStatus(404) to match")
+            }
+        }
+
+        @Test("range match on Kind for 5xx")
+        func rangeMatch() {
+            let kind = NetworkError.Kind.invalidStatus(503)
+            switch kind {
+            case .invalidStatus(500...):
+                break // passes
+            default:
+                Issue.record("Expected .invalidStatus(503) to match 500...")
+            }
+        }
+    }
+
+    @Suite("Direct Pattern Matching on NetworkError")
+    struct DirectPatternMatching {
+        @Test("exact Int match on NetworkError")
+        func exactIntMatch() {
+            let error = NetworkError.http(statusCode: 404)
+            switch error {
+            case 404:
+                break // passes
+            default:
+                Issue.record("Expected NetworkError to match 404")
+            }
+        }
+
+        @Test("range match on NetworkError for 5xx")
+        func rangeMatch() {
+            let error = NetworkError.http(statusCode: 503)
+            switch error {
+            case 500...:
+                break // passes
+            default:
+                Issue.record("Expected NetworkError to match 500...")
+            }
+        }
+
+        @Test("non-invalidStatus kind does not match any status code")
+        func nonStatusKindNoMatch() {
+            let error = NetworkError.transportError(URLError(.timedOut))
+            switch error {
+            case 500:
+                Issue.record("transportFailed should not match status codes")
+            default:
+                break // passes
+            }
+        }
+    }
+
+    @Suite("Convenience Properties with Response")
+    struct ConvenienceWithResponse {
+        static let response = Response(
+            statusCode: 404,
+            headers: [.contentType: "application/json"],
+            body: Data("not found".utf8)
+        )
+        static let error = NetworkError(
+            kind: .invalidStatus(404),
+            request: .get("/test"),
+            response: response
+        )
+
+        @Test("statusCode returns response status code")
+        func statusCode() {
+            #expect(error.statusCode == 404)
+        }
+
+        @Test("body returns response body")
+        func body() {
+            #expect(error.body == Data("not found".utf8))
+        }
+
+        @Test("headers returns response headers")
+        func headers() {
+            #expect(error.headers == [.contentType: "application/json"])
+        }
+
+        @Test("isClientError is true for 4xx")
+        func isClientError() {
+            #expect(error.isClientError == true)
+        }
+
+        @Test("isServerError is false for 4xx")
+        func isServerError() {
+            #expect(error.isServerError == false)
+        }
+
+        @Test("isServerError is true for 5xx")
+        func serverError() {
+            let serverError = NetworkError(
+                kind: .invalidStatus(500),
+                request: .get("/test"),
+                response: Response(statusCode: 500, headers: [:], body: Data())
+            )
+            #expect(serverError.isServerError == true)
+            #expect(serverError.isClientError == false)
+        }
+    }
+
+    @Suite("Convenience Properties without Response")
+    struct ConvenienceWithoutResponse {
+        static let error = NetworkError(
+            kind: .transportFailed(URLError(.notConnectedToInternet)),
+            request: .get("/test"),
+            response: nil
+        )
+
+        @Test("statusCode is nil")
+        func statusCode() {
+            #expect(error.statusCode == nil)
+        }
+
+        @Test("body is nil")
+        func body() {
+            #expect(error.body == nil)
+        }
+
+        @Test("headers is nil")
+        func headers() {
+            #expect(error.headers == nil)
+        }
+
+        @Test("isClientError is false")
+        func isClientError() {
+            #expect(error.isClientError == false)
+        }
+
+        @Test("isServerError is false")
+        func isServerError() {
+            #expect(error.isServerError == false)
+        }
+    }
+
+    @Suite("Factory Methods")
+    struct FactoryMethods {
+        @Test("http(statusCode:) creates invalidStatus error")
+        func httpFactory() {
+            let error = NetworkError.http(statusCode: 500)
+            if case .invalidStatus(500) = error.kind {
+                // passes
+            } else {
+                Issue.record("Expected .invalidStatus(500)")
+            }
+        }
+
+        @Test("transportError creates transportFailed error")
+        func transportFactory() {
+            let underlying = URLError(.timedOut)
+            let error = NetworkError.transportError(underlying)
+            if case .transportFailed = error.kind {
+                // passes
+            } else {
+                Issue.record("Expected .transportFailed")
+            }
+        }
+
+        @Test("factory errors carry stub request")
+        func factoryCarriesStubRequest() {
+            let error = NetworkError.http(statusCode: 404)
+            #expect(error.request.method == .get)
+        }
+    }
+
+    @Suite("Error Conformance")
+    struct ErrorConformance {
+        @Test("NetworkError conforms to Error and can be thrown")
+        func canBeThrown() {
+            let error = NetworkError.http(statusCode: 500)
+            #expect(throws: NetworkError.self) {
+                throw error
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #44

## Description

### Feature

NetworkError struct with Kind enum for categorizing network failures. Supports custom pattern matching (`~=`) for ergonomic status code switching, convenience properties derived from Kind and Response, and test factory helpers.

**Acceptance Criteria:**
- [x] Error struct with kind, request, response
- [x] Kind enum: invalidStatus, decodingFailed, transportFailed, encodingFailed
- [x] Pattern matching on Kind (built-in Swift)
- [x] Custom ~= for direct matching on NetworkError
- [x] Convenience properties (statusCode, body, headers, isClientError, isServerError)
- [x] Convenience properties nil/false without response
- [x] Test factory methods (test-only)

**User Flow:**
Developers catch `NetworkError` and switch on it directly using status codes (`case 404:`, `case 500...:`) or inspect the `kind` for finer control. Convenience properties (`statusCode`, `isClientError`, `isServerError`, `body`, `headers`) provide quick access to error details. Status-related properties derive from Kind; data properties delegate to Response.

---

## Test Plan

- `swift test --filter NetworkErrorTests` — 27 tests across 9 suites
- Full suite: `swift test` — 101 tests passing

---

## Checklist

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [ ] New/changed public API has documentation
- [ ] Breaking changes are noted above